### PR TITLE
自動ビルド: リリースをtgz形式に変更・ルートディレクトリを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,10 +136,12 @@ jobs:
           path: artifact/*
           retention-days: 14
 
-      - name: Rearchive artifact
+      - name: Generate RELEASE_NAME
         run: |
           echo "RELEASE_NAME=${{ matrix.artifact_name }}-${{ env.ONNXRUNTIME_VERSION }}" >> $GITHUB_ENV
 
+      - name: Rearchive artifact
+        run: |
           mv artifact/ "${{ env.RELEASE_NAME }}"
           tar cf "${{ env.RELEASE_NAME }}.tgz" "${{ env.RELEASE_NAME }}/"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,12 +138,14 @@ jobs:
 
       - name: Rearchive artifact
         run: |
-          cd artifact/
-          zip -r ../${{ matrix.artifact_name }}-${{ env.ONNXRUNTIME_VERSION }}.zip *
+          echo "RELEASE_NAME=${{ matrix.artifact_name }}-${{ env.ONNXRUNTIME_VERSION }}" >> $GITHUB_ENV
+
+          mv artifact/ "${{ env.RELEASE_NAME }}"
+          tar cf "${{ env.RELEASE_NAME }}.tgz" "${{ env.RELEASE_NAME }}/"
 
       - name: Upload to Release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }} # ==> github.event.release.tag_name
-          file: ${{ matrix.artifact_name }}-${{ env.ONNXRUNTIME_VERSION }}.zip
+          file: $${{ env.RELEASE_NAME }}.tgz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,4 +148,4 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }} # ==> github.event.release.tag_name
-          file: $${{ env.RELEASE_NAME }}.tgz
+          file: ${{ env.RELEASE_NAME }}.tgz


### PR DESCRIPTION
## 内容

- <https://github.com/VOICEVOX/voicevox_core/issues/54#issuecomment-1003274192>

上のコメントの内容を反映させるPRです。

- 公式Release: <https://github.com/microsoft/onnxruntime/releases/tag/v1.9.0>

公式ReleaseではLinux用のビルドはtgz形式で配布されているので、Releaseにアップロードされる形式をzipからtgzに変更します。
Windows用のビルドが追加されることがあれば、分岐してzipにする形がいいかなと思っています。

また、公式Releaseでは圧縮ファイル内の一番上に、圧縮ファイル名と同名のディレクトリがありますが、このリポジトリのReleaseにはありません。コアのビルドは公式Releaseの構造を前提にしているので、構造を合わせます。

- <https://github.com/aoirint/onnxruntime-builder/releases/tag/1.9.1-aoirint-3>

## 関連Issue

- ref <https://github.com/VOICEVOX/voicevox_core/pull/56>
- ref <https://github.com/VOICEVOX/voicevox_core/issues/54>

## その他

改行コードがCRLFになっているのと、空行が消えているので調整したいです。

`Rearchive artifact`と`Upload to Release`は、Release以外のときにJobが実行されることを想定していないですが、`workflow_dispatch`があるので条件分岐を入れておいた方がよさそうだなと思いました（動いてそうなのでそのままでもいいかもですが）。

