### PR TITLE
リリースの配布形式を修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Rearchive artifact
         run: |
           mv artifact/ "${{ env.RELEASE_NAME }}"
-          tar cf "${{ env.RELEASE_NAME }}.tgz" "${{ env.RELEASE_NAME }}/"
+          tar cfz "${{ env.RELEASE_NAME }}.tgz" "${{ env.RELEASE_NAME }}/"
 
       - name: Upload to Release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
現時点ではtgzという拡張子が付いたただのtarアーカイブになっているので正しい形式に修正します。

(解凍しようとした時の7zipのログの一部)
```
Extracting archive: onnxruntime-linux-armhf-cpu-v1.9.1.tgz
WARNING:
onnxruntime-linux-armhf-cpu-v1.9.1.tgz
Can not open the file as [gzip] archive
The file is open as [tar] archive
```

- ref #2