### PR TITLE
arm64向けOnnx Runtimeの自動ビルドを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,14 @@ jobs:
             ld_symlink_name: ld-linux-armhf.so.3
             build_opts: --arm --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=armv7l --use_openmp --config Release --parallel --update --build --build_shared_lib
             result_dir: build/Linux/Release
+          - artifact_name: onnxruntime-linux-arm64-cpu
+            os: ubuntu-18.04
+            cc_version: '8'
+            cxx_version: '8'
+            arch: aarch64-linux-gnu
+            ld_symlink_name: ld-linux-aarch64.so.1
+            build_opts: --arm64 --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=aarch64 --use_openmp --config Release --parallel --update --build --build_shared_lib
+            result_dir: build/Linux/Release
 
     env:
       ONNXRUNTIME_VERSION: v1.10.0


### PR DESCRIPTION
arm64向けOnnx Runtimeの自動ビルドを追加を追加します。
Raspberry Pi OSでビルドしたVOICEVOX COREが正常に動作することを確認しています。