### PR TITLE
to 1.13.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
             result_dir: build/Linux/Release
 
     env:
-      ONNXRUNTIME_VERSION: v1.10.0
+      ONNXRUNTIME_VERSION: v1.13.1
       # prefix usage: "", "arm-linux-gnueabihf-" => "gcc-8", "arm-linux-gnueabihf-gcc-8" (command name)
       # suffix usage: "", "-arm-linux-gnueabihf" => "gcc-8", "gcc-8-arm-linux-gnueabihf" (package name)
       ARCH_PREFIX: "${{ (matrix.arch != '' && matrix.arch) || '' }}${{ (matrix.arch != '' && '-') || '' }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
             cxx_version: '8'
             arch: arm-linux-gnueabihf
             ld_symlink_name: ld-linux-armhf.so.3
-            build_opts: --arm --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=armv7l --use_openmp --config Release --parallel --update --build --build_shared_lib
+            build_opts: --arm --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=armv7l --config Release --parallel --update --build --build_shared_lib
             result_dir: build/Linux/Release
           - artifact_name: onnxruntime-linux-arm64-cpu
             os: ubuntu-18.04
@@ -29,7 +29,7 @@ jobs:
             cxx_version: '8'
             arch: aarch64-linux-gnu
             ld_symlink_name: ld-linux-aarch64.so.1
-            build_opts: --arm64 --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=aarch64 --use_openmp --config Release --parallel --update --build --build_shared_lib
+            build_opts: --arm64 --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=aarch64 --config Release --parallel --update --build --build_shared_lib
             result_dir: build/Linux/Release
 
     env:


### PR DESCRIPTION
`--use_openmp`引数がなくなってそうだったけど、単純に消すだけで良いのかは不明･･･。