### PR TITLE
iOSビルドの追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,15 +33,15 @@ jobs:
             result_dir: build/Linux/Release
           - artifact_name: onnxruntime-ios-arm64-cpu
             os: macos-12
-            build_opts: --config Release --parallel --update --build --build_shared_lib --skip-tests --use_xcode --ios --ios_sysroot iphoneos --osx_arch arm64 --apple_deploy_target 16.0
+            build_opts: --config Release --parallel --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphoneos --osx_arch arm64 --apple_deploy_target 16.0
             result_dir: build/iOS/Release
           - artifact_name: onnxruntime-ios-sim-arm64-cpu
             os: macos-12
-            build_opts: --config Release --parallel --update --build --build_shared_lib --skip-tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch arm64 --apple_deploy_target 16.0
+            build_opts: --config Release --parallel --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch arm64 --apple_deploy_target 16.0
             result_dir: build/iOS/Release
           - artifact_name: onnxruntime-ios-sim-x86_64-cpu
             os: macos-12
-            build_opts: --config Release --parallel --update --build --build_shared_lib --skip-tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch x86_64 --apple_deploy_target 16.0
+            build_opts: --config Release --parallel --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch x86_64 --apple_deploy_target 16.0
             result_dir: build/iOS/Release
 
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,9 @@ jobs:
             arch: arm-linux-gnueabihf
             symlink_workaround: true
             build_opts: --arm --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=armv7l --config Release --parallel --update --build --build_shared_lib
-            result_dir: build/Linux/Release
+            result_dir: build/Linux
+            release_config: Release
+            library_name: libonnxruntime.so
           - artifact_name: onnxruntime-linux-arm64-cpu
             os: ubuntu-20.04
             cc_version: '8'
@@ -30,19 +32,27 @@ jobs:
             arch: aarch64-linux-gnu
             symlink_workaround: true
             build_opts: --arm64 --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=aarch64 --config Release --parallel --update --build --build_shared_lib
-            result_dir: build/Linux/Release
+            result_dir: build/Linux
+            release_config: Release
+            library_name: libonnxruntime.so
           - artifact_name: onnxruntime-ios-arm64-cpu
             os: macos-12
             build_opts: --config Release --parallel --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphoneos --osx_arch arm64 --apple_deploy_target 16.0
             result_dir: build/iOS/Release
+            release_config: Release-iphoneos
+            library_name: libonnxruntime.dylib
           - artifact_name: onnxruntime-ios-sim-arm64-cpu
             os: macos-12
             build_opts: --config Release --parallel --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch arm64 --apple_deploy_target 16.0
             result_dir: build/iOS/Release
+            release_config: Release-iphonesimulator
+            library_name: libonnxruntime.dylib
           - artifact_name: onnxruntime-ios-sim-x86_64-cpu
             os: macos-12
             build_opts: --config Release --parallel --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch x86_64 --apple_deploy_target 16.0
             result_dir: build/iOS/Release
+            release_config: Release-iphonesimulator
+            library_name: libonnxruntime.dylib
 
     env:
       ONNXRUNTIME_VERSION: v1.14.1
@@ -123,41 +133,15 @@ jobs:
           bash ./build.sh ${{ matrix.build_opts }}
       
       - name: Organize artifact
+        shell: bash
         run: |
-          mkdir artifact
-
-          # copy shared lib
-          mkdir artifact/lib
-
-          NAME=$(basename ${{ matrix.result_dir }}/libonnxruntime.{so.*,dylib})
-          cp "${{ matrix.result_dir }}/${NAME}" artifact/lib/ || true
-          ln -s "${NAME}" artifact/lib/libonnxruntime.{so,dylib} || true
-
-          # copy header files
-          mkdir artifact/include
-
-          readarray -t HEADERS <<EOF
-          onnxruntime/core/session/onnxruntime_c_api.h
-          onnxruntime/core/session/onnxruntime_cxx_api.h
-          onnxruntime/core/session/onnxruntime_cxx_inline.h
-          onnxruntime/core/providers/cpu/cpu_provider_factory.h
-          onnxruntime/core/session/onnxruntime_session_options_config_keys.h
-          onnxruntime/core/session/onnxruntime_run_options_config_keys.h
-          onnxruntime/core/framework/provider_options.h
-          EOF
-
-          for path in "${HEADERS[@]}"; do
-            cp "include/${path}" ./artifact/include/
-          done
-
-          # copy docs & license
-          cp VERSION_NUMBER ./artifact/
-          cp LICENSE ./artifact/
-          cp ThirdPartyNotices.txt ./artifact/
-          cp docs/Privacy.md ./artifact/
-          cp README.md ./artifact/
-
-          echo "$(git rev-parse HEAD)" >> ./artifact/GIT_COMMIT_ID
+          ./tools/ci_build/github/linux/copy_strip_binary.sh \
+            -r ${{ matrix.result_dir }} \
+            -a ${{ matrix.artifact_name }} \
+            -l ${{ matrix.library_name }} \
+            -c ${{ matrix.release_config }} \
+            -s "$(pwd)" \
+            -t "$(git rev-parse HEAD)"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,18 @@ jobs:
             symlink_workaround: true
             build_opts: --arm64 --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=aarch64 --config Release --parallel --update --build --build_shared_lib
             result_dir: build/Linux/Release
+          - artifact_name: onnxruntime-ios-arm64-cpu
+            os: macos-12
+            build_opts: --config Release --parallel --update --build --build_shared_lib --skip-tests --use_xcode --ios --ios_sysroot iphoneos --osx_arch arm64 --apple_deploy_target 16.0
+            result_dir: build/iOS/Release
+          - artifact_name: onnxruntime-ios-sim-arm64-cpu
+            os: macos-12
+            build_opts: --config Release --parallel --update --build --build_shared_lib --skip-tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch arm64 --apple_deploy_target 16.0
+            result_dir: build/iOS/Release
+          - artifact_name: onnxruntime-ios-sim-x86_64-cpu
+            os: macos-12
+            build_opts: --config Release --parallel --update --build --build_shared_lib --skip-tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch x86_64 --apple_deploy_target 16.0
+            result_dir: build/iOS/Release
 
     env:
       ONNXRUNTIME_VERSION: v1.14.1
@@ -62,7 +74,7 @@ jobs:
           key: ${{ matrix.artifact_name }}-${{ env.ONNXRUNTIME_VERSION }}-cache-v1-${{ hashFiles('matrix.json') }}
 
       - name: Install build dependencies
-        if: steps.cache-build-result.outputs.cache-hit != 'true'
+        if: steps.cache-build-result.outputs.cache-hit != 'true' && startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -76,7 +88,7 @@ jobs:
       
       # ONNX Runtime v1.14.1 requires CMake 3.24 or higher.
       - name: Install CMake
-        if: steps.cache-build-result.outputs.cache-hit != 'true'
+        if: steps.cache-build-result.outputs.cache-hit != 'true' && startsWith(matrix.os, 'ubuntu')
         env:
           CMAKE_VERSION: 3.24.4
         run: |
@@ -84,7 +96,7 @@ jobs:
           sudo bash cmake.sh --skip-license --prefix=/usr/local
 
       - name: Configure build environment
-        if: steps.cache-build-result.outputs.cache-hit != 'true'
+        if: steps.cache-build-result.outputs.cache-hit != 'true' && startsWith(matrix.os, 'ubuntu')
         run: |
           # Required for arm build
           # https://github.com/microsoft/onnxruntime/issues/4189#issuecomment-642528278
@@ -116,9 +128,9 @@ jobs:
           # copy shared lib
           mkdir artifact/lib
 
-          NAME=$(basename ${{ matrix.result_dir }}/libonnxruntime.so.*)
+          NAME=$(basename ${{ matrix.result_dir }}/libonnxruntime.{so.*,dylib})
           cp "${{ matrix.result_dir }}/${NAME}" artifact/lib/
-          ln -s "${NAME}" artifact/lib/libonnxruntime.so
+          ln -s "${NAME}" artifact/lib/libonnxruntime.{so,dylib}
 
           # copy header files
           mkdir artifact/include

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,8 +130,8 @@ jobs:
           mkdir artifact/lib
 
           NAME=$(basename ${{ matrix.result_dir }}/libonnxruntime.{so.*,dylib})
-          cp "${{ matrix.result_dir }}/${NAME}" artifact/lib/
-          ln -s "${NAME}" artifact/lib/libonnxruntime.{so,dylib}
+          cp "${{ matrix.result_dir }}/${NAME}" artifact/lib/ || true
+          ln -s "${NAME}" artifact/lib/libonnxruntime.{so,dylib} || true
 
           # copy header files
           mkdir artifact/include

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
             build_opts: --arm --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=armv7l --config Release --parallel --update --build --build_shared_lib
             result_dir: build/Linux
             release_config: Release
-            library_name: libonnxruntime.so
+            library_extension: so
           - artifact_name: onnxruntime-linux-arm64-cpu
             os: ubuntu-20.04
             cc_version: '8'
@@ -34,25 +34,25 @@ jobs:
             build_opts: --arm64 --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=aarch64 --config Release --parallel --update --build --build_shared_lib
             result_dir: build/Linux
             release_config: Release
-            library_name: libonnxruntime.so
+            library_extension: so
           - artifact_name: onnxruntime-ios-arm64-cpu
             os: macos-12
             build_opts: --config Release --parallel --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphoneos --osx_arch arm64 --apple_deploy_target 16.0
             result_dir: build/iOS/Release
             release_config: Release-iphoneos
-            library_name: libonnxruntime.dylib
+            library_extension: dylib
           - artifact_name: onnxruntime-ios-sim-arm64-cpu
             os: macos-12
             build_opts: --config Release --parallel --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch arm64 --apple_deploy_target 16.0
             result_dir: build/iOS/Release
             release_config: Release-iphonesimulator
-            library_name: libonnxruntime.dylib
+            library_extension: dylib
           - artifact_name: onnxruntime-ios-sim-x86_64-cpu
             os: macos-12
             build_opts: --config Release --parallel --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch x86_64 --apple_deploy_target 16.0
             result_dir: build/iOS/Release
             release_config: Release-iphonesimulator
-            library_name: libonnxruntime.dylib
+            library_extension: dylib
 
     env:
       ONNXRUNTIME_VERSION: v1.14.1
@@ -138,7 +138,7 @@ jobs:
           ./tools/ci_build/github/linux/copy_strip_binary.sh \
             -r ${{ matrix.result_dir }} \
             -a ${{ matrix.artifact_name }} \
-            -l ${{ matrix.library_name }} \
+            -l libonnxruntime.${{ env.ONNXRUNTIME_VERSION }}.${{ matrix.library_extension }} \
             -c ${{ matrix.release_config }} \
             -s "$(pwd)" \
             -t "$(git rev-parse HEAD)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,10 +109,6 @@ jobs:
             sudo ln -s /usr/${{ matrix.arch }}/lib/ld-linux-*.so* /usr/lib/
           fi
       
-      - name: Prepare Xcode for build iOS target
-        if: startsWith(matrix.os, 'macos')
-        run: sudo xcode-select --reset
-
       - name: Build ONNX Runtime
         if: steps.cache-build-result.outputs.cache-hit != 'true'
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Organize artifact
         shell: bash
         run: |
+          # コピー先artifactを予め削除しておく
+          rm -r ${{ matrix.result_dir }}/${{ matrix.artifact_name }} || true
+          rm -r ./artifact || true
           # バージョンにはvが必要ないので取り除く
           ONNXRUNTIME_VERSION=${{ env.ONNXRUNTIME_VERSION }}
           ONNXRUNTIME_VERSION=${ONNXRUNTIME_VERSION:1}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,6 +149,7 @@ jobs:
             -c ${{ matrix.release_config }} \
             -s "$(pwd)" \
             -t "$(git rev-parse HEAD)"
+          mv ${{ matrix.result_dir }}/${{ matrix.artifact_name }} ./artifact/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
           ./tools/ci_build/github/linux/copy_strip_binary.sh \
             -r ${{ matrix.result_dir }} \
             -a ${{ matrix.artifact_name }} \
-            -l libonnxruntime.${{ env.ONNXRUNTIME_VERSION:1 }}.${{ matrix.library_extension }} \
+            -l libonnxruntime.${{ env.ONNXRUNTIME_VERSION }}.${{ matrix.library_extension }} \
             -c ${{ matrix.release_config }} \
             -s "$(pwd)" \
             -t "$(git rev-parse HEAD)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,10 +135,13 @@ jobs:
       - name: Organize artifact
         shell: bash
         run: |
+          # バージョンにはvが必要ないので取り除く
+          ONNXRUNTIME_VERSION=${{ env.ONNXRUNTIME_VERSION }}
+          ONNXRUNTIME_VERSION=${ONNXRUNTIME_VERSION:1}
           ./tools/ci_build/github/linux/copy_strip_binary.sh \
             -r ${{ matrix.result_dir }} \
             -a ${{ matrix.artifact_name }} \
-            -l libonnxruntime.${{ env.ONNXRUNTIME_VERSION }}.${{ matrix.library_extension }} \
+            -l "libonnxruntime.$ONNXRUNTIME_VERSION.${{ matrix.library_extension }}" \
             -c ${{ matrix.release_config }} \
             -s "$(pwd)" \
             -t "$(git rev-parse HEAD)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,8 +131,8 @@ jobs:
         shell: bash
         run: |
           # コピー先artifactを予め削除しておく
-          rm -r ${{ matrix.result_dir }}/${{ matrix.artifact_name }} || true
-          rm -r ./artifact || true
+          rm -rf ${{ matrix.result_dir }}/${{ matrix.artifact_name }}
+          rm -rf ./artifact
           # バージョンにはvが必要ないので取り除く
           ONNXRUNTIME_VERSION=${{ env.ONNXRUNTIME_VERSION }}
           ONNXRUNTIME_VERSION=${ONNXRUNTIME_VERSION:1}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,10 @@ jobs:
             sudo ln -s /usr/${{ matrix.arch }}/lib/ld-linux-*.so* /usr/lib/
           fi
       
+      - name: Prepare Xcode for build iOS target
+        if: startsWith(matrix.os, 'macos')
+        run: sudo xcode-select --reset
+
       - name: Build ONNX Runtime
         if: steps.cache-build-result.outputs.cache-hit != 'true'
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,12 +108,13 @@ jobs:
             find /usr/${{ matrix.arch }}/lib -name '*.so*' -exec sudo ln -s {} /usr/lib/${{ matrix.arch }}/ ';'
             sudo ln -s /usr/${{ matrix.arch }}/lib/ld-linux-*.so* /usr/lib/
           fi
+
+          # Set environment variable CC / CXX
+          echo "CC=${{ env.ARCH_PREFIX }}gcc-${{ matrix.cc_version }}" >> "$GITHUB_ENV"
+          echo "CXX=${{ env.ARCH_PREFIX }}g++-${{ matrix.cxx_version }}" >> "$GITHUB_ENV"
       
       - name: Build ONNX Runtime
         if: steps.cache-build-result.outputs.cache-hit != 'true'
-        env:
-          CC: ${{ env.ARCH_PREFIX }}gcc-${{ matrix.cc_version }}
-          CXX: ${{ env.ARCH_PREFIX }}g++-${{ matrix.cxx_version }}
         run: |
           # add --arm for gcc-8: https://github.com/microsoft/onnxruntime/issues/4189
           # skip test: https://github.com/microsoft/onnxruntime/issues/2436

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
           ./tools/ci_build/github/linux/copy_strip_binary.sh \
             -r ${{ matrix.result_dir }} \
             -a ${{ matrix.artifact_name }} \
-            -l libonnxruntime.${{ env.ONNXRUNTIME_VERSION }}.${{ matrix.library_extension }} \
+            -l libonnxruntime.${{ env.ONNXRUNTIME_VERSION:1 }}.${{ matrix.library_extension }} \
             -c ${{ matrix.release_config }} \
             -s "$(pwd)" \
             -t "$(git rev-parse HEAD)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
             build_opts: --arm --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=armv7l --config Release --parallel --update --build --build_shared_lib
             result_dir: build/Linux
             release_config: Release
-            library_extension: so
           - artifact_name: onnxruntime-linux-arm64-cpu
             os: ubuntu-20.04
             cc_version: '8'
@@ -34,25 +33,21 @@ jobs:
             build_opts: --arm64 --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=aarch64 --config Release --parallel --update --build --build_shared_lib
             result_dir: build/Linux
             release_config: Release
-            library_extension: so
           - artifact_name: onnxruntime-ios-arm64-cpu
             os: macos-12
             build_opts: --config Release --parallel --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphoneos --osx_arch arm64 --apple_deploy_target 16.0
             result_dir: build/iOS/Release
             release_config: Release-iphoneos
-            library_extension: dylib
           - artifact_name: onnxruntime-ios-sim-arm64-cpu
             os: macos-12
             build_opts: --config Release --parallel --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch arm64 --apple_deploy_target 16.0
             result_dir: build/iOS/Release
             release_config: Release-iphonesimulator
-            library_extension: dylib
           - artifact_name: onnxruntime-ios-sim-x86_64-cpu
             os: macos-12
             build_opts: --config Release --parallel --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch x86_64 --apple_deploy_target 16.0
             result_dir: build/iOS/Release
             release_config: Release-iphonesimulator
-            library_extension: dylib
 
     env:
       ONNXRUNTIME_VERSION: v1.14.1
@@ -131,17 +126,26 @@ jobs:
           # ONNX Runtime v1.9.0 requires CMAKE_SYSTEM_PROCESSOR, https://github.com/microsoft/onnxruntime/releases/tag/v1.9.0
           # Both CMAKE_SYSTEM_NAME and CMAKE_SYSTEM_PROCESSOR are required.
           bash ./build.sh ${{ matrix.build_opts }}
-      
+
       - name: Organize artifact
         shell: bash
         run: |
           # バージョンにはvが必要ないので取り除く
           ONNXRUNTIME_VERSION=${{ env.ONNXRUNTIME_VERSION }}
           ONNXRUNTIME_VERSION=${ONNXRUNTIME_VERSION:1}
+          # Set library name
+          if [[ ${{ matrix.artifact_name }} == onnxruntime-linux-* ]]; then
+            ONNXRUNTIME_NAME=libonnxruntime.so.$ONNXRUNTIME_VERSION
+          elif [[ ${{ matrix.artifact_name }} == onnxruntime-ios-* ]]; then
+            ONNXRUNTIME_NAME=libonnxruntime.$ONNXRUNTIME_VERSION.dylib
+          else
+            echo "Unknown target found : ${{ matrix.artifact_name }}"
+            return 1
+          fi
           ./tools/ci_build/github/linux/copy_strip_binary.sh \
             -r ${{ matrix.result_dir }} \
             -a ${{ matrix.artifact_name }} \
-            -l "libonnxruntime.$ONNXRUNTIME_VERSION.${{ matrix.library_extension }}" \
+            -l $ONNXRUNTIME_NAME \
             -c ${{ matrix.release_config }} \
             -s "$(pwd)" \
             -t "$(git rev-parse HEAD)"


### PR DESCRIPTION
onnxruntimeのiOSビルドを追加します。


## 変更点

* iOSのターゲットを追加しました
  - aarch64-apple-ios
  - aarch64-apple-ios-sim
  - x86_64-apple-ios
* Linux向けビルドでのみ必要な要素を`startsWith(matrix.os, 'ubuntu')`によって切り分けました
* Artifact作成操作を、onnxruntimeのリポジトリで利用されている[`copy_strip_binary.sh`](https://github.com/microsoft/onnxruntime/blob/main/tools/ci_build/github/linux/copy_strip_binary.sh)へ変更しました
  - これにより成果物の位置が異なるため、最終成果物は`./artifact`へ移動しています

## 関連Issue / PR

* https://github.com/VOICEVOX/voicevox_core/issues/459
* https://github.com/VOICEVOX/onnxruntime-rs/pull/19

## 成果物

iOS向け成果物は以下のReleasesにあります。
https://github.com/HyodaKazuaki/onnxruntime-builder/releases/tag/v1.14.1-ios-test3