### PR TITLE
iOS向けXCFrameworkを追加する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
           7z a "../${{ env.RELEASE_NAME }}.zip" "${{ env.ONNXRUNTIME_BASENAME }}"
 
       - name: Upload to Release
-        if: env.VERSION != '0.0.0' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
+        if: env.RELEASE == 'true'
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,7 +214,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: onnxruntime-ios-arm64
-          path: artifact/onnxruntime-x86_64-apple-ios
+          path: artifact/onnxruntime-aarch64-apple-ios
 
       - uses: actions/download-artifact@v2
         with:
@@ -224,7 +224,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: onnxruntime-ios-sim-x86_64
-          path: artifact/onnxruntime-aarch64-apple-ios
+          path: artifact/onnxruntime-x86_64-apple-ios
 
       - name: Remove no version notation dylib
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,7 +207,6 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Generate RELEASE_NAME and ONNXRUNTIME_BASENAME
-        if: env.RELEASE == 'true'
         run: |
           echo "RELEASE_NAME=onnxruntime-xcframework-${{ env.ONNXRUNTIME_VERSION }}" >> $GITHUB_ENV
           echo "ONNXRUNTIME_BASENAME=libonnxruntime.${{ env.ONNXRUNTIME_VERSION }}.dylib" >> "$GITHUB_ENV"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,7 +195,7 @@ jobs:
           tar cfz "${{ env.RELEASE_NAME }}.tgz" "${{ env.RELEASE_NAME }}/"
 
       - name: Upload to Release
-        if: env.RELEASE == 'true'
+        if: env.RELEASE == 'true' && !contains(matrix.artifact_name, 'ios')
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,7 +195,7 @@ jobs:
           tar cfz "${{ env.RELEASE_NAME }}.tgz" "${{ env.RELEASE_NAME }}/"
 
       - name: Upload to Release
-        if: env.RELEASE == 'true' && !contains(matrix.artifact_name, 'ios')
+        if: env.RELEASE == 'true'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,10 +206,11 @@ jobs:
     needs: build-onnxruntime
     runs-on: macos-12
     steps:
-      - name: Generate RELEASE_NAME
+      - name: Generate RELEASE_NAME and ONNXRUNTIME_BASENAME
         if: env.RELEASE == 'true'
         run: |
           echo "RELEASE_NAME=onnxruntime-xcframework-${{ env.ONNXRUNTIME_VERSION }}" >> $GITHUB_ENV
+          echo "ONNXRUNTIME_BASENAME=libonnxruntime.${{ env.ONNXRUNTIME_VERSION }}.dylib" >> "$GITHUB_ENV"
 
       - uses: actions/download-artifact@v2
         with:
@@ -232,11 +233,6 @@ jobs:
           rm -f artifact/onnxruntime-x86_64-apple-ios/lib/*onnxruntime.dylib
           rm -f artifact/onnxruntime-aarch64-apple-ios-sim/lib/*onnxruntime.dylib
           rm -f artifact/onnxruntime-aarch64-apple-ios/lib/*onnxruntime.dylib
-
-      - name: Set basename env var
-        shell: bash
-        run: |
-          echo "ONNXRUNTIME_BASENAME=$(find artifact/onnxruntime-x86_64-apple-ios/lib -type f -name '*onnxruntime*.dylib' -exec basename {} \;)" >> "$GITHUB_ENV"
 
       - name: Create fat binary
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,10 +256,9 @@ jobs:
 
       - name: Upload to Release
         if: env.RELEASE == 'true'
-        uses: softprops/action-gh-release@v1
+        uses: svenstaro/upload-release-action@v2
         with:
-          prerelease: true
-          tag_name: ${{ env.VERSION }}
-          files: |-
-            ${{ env.RELEASE_NAME }}.zip
-          target_commitish: ${{ github.sha }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.ONNXRUNTIME_VERSION }} # ==> github.event.release.tag_name
+          file: ${{ env.RELEASE_NAME }}.zip
+  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,3 +201,70 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.ONNXRUNTIME_VERSION }} # ==> github.event.release.tag_name
           file: ${{ env.RELEASE_NAME }}.tgz
+  
+  build-xcframework:
+    needs: build-onnxruntime
+    runs-on: macos-12
+    steps:
+      - name: Generate RELEASE_NAME
+        if: env.RELEASE == 'true'
+        run: |
+          echo "RELEASE_NAME=onnxruntime-xcframework-${{ env.ONNXRUNTIME_VERSION }}" >> $GITHUB_ENV
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: onnxruntime-ios-arm64
+          path: artifact/onnxruntime-x86_64-apple-ios
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: onnxruntime-ios-sim-arm64
+          path: artifact/onnxruntime-aarch64-apple-ios-sim
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: onnxruntime-ios-sim-x86_64
+          path: artifact/onnxruntime-aarch64-apple-ios
+
+      - name: Remove no version notation dylib
+        shell: bash
+        run: |
+          rm -f artifact/onnxruntime-x86_64-apple-ios/lib/*onnxruntime.dylib
+          rm -f artifact/onnxruntime-aarch64-apple-ios-sim/lib/*onnxruntime.dylib
+          rm -f artifact/onnxruntime-aarch64-apple-ios/lib/*onnxruntime.dylib
+
+      - name: Set basename env var
+        shell: bash
+        run: |
+          echo "ONNXRUNTIME_BASENAME=$(find artifact/onnxruntime-x86_64-apple-ios/lib -type f -name '*onnxruntime*.dylib' -exec basename {} \;)" >> "$GITHUB_ENV"
+
+      - name: Create fat binary
+        shell: bash
+        run: |
+          mkdir -p "artifact/onnxruntime-sim"
+          lipo -create "artifact/onnxruntime-x86_64-apple-ios/lib/${{ env.ONNXRUNTIME_BASENAME }}" "artifact/onnxruntime-aarch64-apple-ios-sim/lib/${{ env.ONNXRUNTIME_BASENAME }}" -output "artifact/onnxruntime-sim/lib/${{ env.ONNXRUNTIME_BASENAME }}"
+
+      - name: Create XCFramework
+        shell: bash
+        run: |
+          mkdir -p "artifact/${{ env.ONNXRUNTIME_BASENAME }}"
+          xcodebuild -create-xcframework \
+            -library "artifact/onnxruntime-sim/${{ env.ONNXRUNTIME_BASENAME }}" \
+            -library "artifact/onnxruntime-aarch64-apple-ios/lib/${{ env.ONNXRUNTIME_BASENAME }}" \
+            -output "artifact/${{ env.ONNXRUNTIME_BASENAME }}/onnxruntime.xcframework"
+
+      - name: Archive artifact
+        shell: bash
+        run: |
+          cd artifact
+          7z a "../${{ env.RELEASE_NAME }}.zip" "${{ env.ONNXRUNTIME_BASENAME }}"
+
+      - name: Upload to Release
+        if: env.VERSION != '0.0.0' && env.SKIP_UPLOADING_RELEASE_ASSET == '0'
+        uses: softprops/action-gh-release@v1
+        with:
+          prerelease: true
+          tag_name: ${{ env.VERSION }}
+          files: |-
+            ${{ env.RELEASE_NAME }}.zip
+          target_commitish: ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,8 +251,8 @@ jobs:
       - name: Archive artifact
         shell: bash
         run: |
-          cd artifact
-          7z a "../${{ env.RELEASE_NAME }}.zip" "${{ env.ONNXRUNTIME_BASENAME }}"
+          cd artifact/${{ env.ONNXRUNTIME_BASENAME }}
+          7z a "../../${{ env.RELEASE_NAME }}.zip" "onnxruntime.xcframework"
 
       - name: Upload to Release
         if: env.RELEASE == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,7 +237,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p "artifact/onnxruntime-sim"
-          lipo -create "artifact/onnxruntime-x86_64-apple-ios/lib/${{ env.ONNXRUNTIME_BASENAME }}" "artifact/onnxruntime-aarch64-apple-ios-sim/lib/${{ env.ONNXRUNTIME_BASENAME }}" -output "artifact/onnxruntime-sim/lib/${{ env.ONNXRUNTIME_BASENAME }}"
+          lipo -create "artifact/onnxruntime-x86_64-apple-ios/lib/${{ env.ONNXRUNTIME_BASENAME }}" "artifact/onnxruntime-aarch64-apple-ios-sim/lib/${{ env.ONNXRUNTIME_BASENAME }}" -output "artifact/onnxruntime-sim/${{ env.ONNXRUNTIME_BASENAME }}"
 
       - name: Create XCFramework
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,10 +205,12 @@ jobs:
   build-xcframework:
     needs: build-onnxruntime
     runs-on: macos-12
-    env:
-      RELEASE_NAME: onnxruntime-xcframework-${{ env.ONNXRUNTIME_VERSION }}
-      ONNXRUNTIME_BASENAME: libonnxruntime.${{ env.ONNXRUNTIME_VERSION }}.dylib
     steps:
+      - name: Generate RELEASE_NAME and ONNXRUNTIME_BASENAME
+        run: |
+          echo "RELEASE_NAME=onnxruntime-xcframework-${{ env.ONNXRUNTIME_VERSION }}" >> $GITHUB_ENV
+          echo "ONNXRUNTIME_BASENAME=libonnxruntime.${{ env.ONNXRUNTIME_VERSION }}.dylib" >> "$GITHUB_ENV"
+
       - uses: actions/download-artifact@v2
         with:
           name: onnxruntime-ios-arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,12 +205,10 @@ jobs:
   build-xcframework:
     needs: build-onnxruntime
     runs-on: macos-12
+    env:
+      RELEASE_NAME: onnxruntime-xcframework-${{ env.ONNXRUNTIME_VERSION }}
+      ONNXRUNTIME_BASENAME: libonnxruntime.${{ env.ONNXRUNTIME_VERSION }}.dylib
     steps:
-      - name: Generate RELEASE_NAME and ONNXRUNTIME_BASENAME
-        run: |
-          echo "RELEASE_NAME=onnxruntime-xcframework-${{ env.ONNXRUNTIME_VERSION }}" >> $GITHUB_ENV
-          echo "ONNXRUNTIME_BASENAME=libonnxruntime.${{ env.ONNXRUNTIME_VERSION }}.dylib" >> "$GITHUB_ENV"
-
       - uses: actions/download-artifact@v2
         with:
           name: onnxruntime-ios-arm64


### PR DESCRIPTION
## 内容

iOS向けのXCFrameworkをビルドするGitHub Actionsを追加します。

このPRでは次の要素を追加しました。

1. 各ターゲット向けdylibのUpload(`build-onnxruntime` job上)
2. シミュレータ向けdylibのFat binary化(`build_xcframework` job上)
3. XCFrameworkの作成(`build_xcframework` job上)

## 関連 Issue

close #18 
https://github.com/VOICEVOX/voicevox_core/issues/477
https://github.com/VOICEVOX/voicevox_core/pull/485
