### PR TITLE
xcframeworkの命名規則を変える

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,14 +201,14 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.ONNXRUNTIME_VERSION }} # ==> github.event.release.tag_name
           file: ${{ env.RELEASE_NAME }}.tgz
-  
+
   build-xcframework:
     needs: build-onnxruntime
     runs-on: macos-12
     steps:
       - name: Generate RELEASE_NAME and ONNXRUNTIME_BASENAME
         run: |
-          echo "RELEASE_NAME=onnxruntime-xcframework-${{ env.ONNXRUNTIME_VERSION }}" >> $GITHUB_ENV
+          echo "RELEASE_NAME=onnxruntime-ios-xcframework-${{ env.ONNXRUNTIME_VERSION }}" >> $GITHUB_ENV
           echo "ONNXRUNTIME_BASENAME=libonnxruntime.${{ env.ONNXRUNTIME_VERSION }}.dylib" >> "$GITHUB_ENV"
 
       - uses: actions/download-artifact@v2
@@ -261,4 +261,3 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.ONNXRUNTIME_VERSION }} # ==> github.event.release.tag_name
           file: ${{ env.RELEASE_NAME }}.zip
-  


### PR DESCRIPTION
## 内容

xcframeworkはmacOSでも存在し得るらしいです。
ここでアップロードされているxcframeworkはios専用なので、そのことがわかるように`ios-`prefixを追加します。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_core/pull/485#discussion_r1199254761

## その他

ちなみに本家のonnxruntimeの命名はこんな感じです。
https://github.com/microsoft/onnxruntime/releases/tag/v1.14.1
