### PR TITLE
Github Actionsでshell: bashを毎回書かなくても良いようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,10 @@ env:
     |- # releaseタグ名か、workflow_dispatchでのreleaseフラグがあればリリースする
     ${{ github.event.release.tag_name != '' || github.event.inputs.release == 'true' }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build-onnxruntime:
     strategy:
@@ -74,7 +78,6 @@ jobs:
 
     steps:
       - name: Version check (semver)
-        shell: bash
         run: |
           VERSION="${{ env.ONNXRUNTIME_VERSION }}"
           if [[ $VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]]; then
@@ -153,7 +156,6 @@ jobs:
           bash ./build.sh ${{ matrix.build_opts }}
 
       - name: Organize artifact
-        shell: bash
         run: |
           # コピー先artifactを予め削除しておく
           rm -rf ${{ matrix.result_dir }}/${{ matrix.artifact_name }}
@@ -227,20 +229,17 @@ jobs:
           path: artifact/onnxruntime-x86_64-apple-ios
 
       - name: Remove no version notation dylib
-        shell: bash
         run: |
           rm -f artifact/onnxruntime-x86_64-apple-ios/lib/*onnxruntime.dylib
           rm -f artifact/onnxruntime-aarch64-apple-ios-sim/lib/*onnxruntime.dylib
           rm -f artifact/onnxruntime-aarch64-apple-ios/lib/*onnxruntime.dylib
 
       - name: Create fat binary
-        shell: bash
         run: |
           mkdir -p "artifact/onnxruntime-sim"
           lipo -create "artifact/onnxruntime-x86_64-apple-ios/lib/${{ env.ONNXRUNTIME_BASENAME }}" "artifact/onnxruntime-aarch64-apple-ios-sim/lib/${{ env.ONNXRUNTIME_BASENAME }}" -output "artifact/onnxruntime-sim/${{ env.ONNXRUNTIME_BASENAME }}"
 
       - name: Create XCFramework
-        shell: bash
         run: |
           mkdir -p "artifact/${{ env.ONNXRUNTIME_BASENAME }}"
           xcodebuild -create-xcframework \
@@ -249,7 +248,6 @@ jobs:
             -output "artifact/${{ env.ONNXRUNTIME_BASENAME }}/onnxruntime.xcframework"
 
       - name: Archive artifact
-        shell: bash
         run: |
           cd artifact/${{ env.ONNXRUNTIME_BASENAME }}
           7z a "../../${{ env.RELEASE_NAME }}.zip" "onnxruntime.xcframework"


### PR DESCRIPTION
## 内容

shell: bashを不要にできるオプションがあったので指定してみました。
とりあえずubuntu以外でのOSで実行していたworkflowにのみ付けています。
https://docs.github.com/ja/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun
