### PR TITLE
macOSのarm64ビルドが正しくできるよう修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,12 +86,12 @@ jobs:
             release_config: Release
           - artifact_name: onnxruntime-osx-arm64
             os: macos-12
-            build_opts: --arm64 --cmake_extra_defines CMAKE_SYSTEM_NAME=Darwin CMAKE_SYSTEM_PROCESSOR=aarch64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
+            build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Darwin CMAKE_OSX_ARCHITECTURES=arm64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
             result_dir: build
             release_config: Release
           - artifact_name: onnxruntime-osx-x86_64
             os: macos-12
-            build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Darwin CMAKE_SYSTEM_PROCESSOR=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
+            build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Darwin CMAKE_OSX_ARCHITECTURES=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
             result_dir: build
             release_config: Release
           - artifact_name: onnxruntime-android-x64


### PR DESCRIPTION
## 内容
macOSのarm64ビルドが正しくできるよう修正
現行のビルドスクリプトでは、`onnxruntime-osx-arm64`  が x86_64になってしまう問題を修正します

## スクリーンショット・動画など
[Release 1.16.3](https://github.com/VOICEVOX/onnxruntime-builder/releases/tag/1.16.3) から `onnxruntime-osx-arm64-1.16.3.tgz` をDLして、下記コマンドを実行すると確認できます。

```
>  file onnxruntime-osx-arm64-1.16.3/lib/libonnxruntime.dylib
onnxruntime-osx-x86_64-1.16.3/lib/libonnxruntime.1.16.3.dylib: Mach-O 64-bit dynamically linked shared library x86_64
```

本PRをマージして、再ビルドすると下記のようになるはずです

```
onnxruntime-osx-arm64-1.16.3/lib/libonnxruntime.dylib: Mach-O 64-bit dynamically linked shared library arm64
```

## その他
