### PR TITLE
macOS用のものを`macos-11`でビルドする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,12 +85,12 @@ jobs:
             result_dir: build
             release_config: Release
           - artifact_name: onnxruntime-osx-arm64
-            os: macos-12
+            os: macos-11
             build_opts: --arm64 --cmake_extra_defines CMAKE_SYSTEM_NAME=Darwin CMAKE_SYSTEM_PROCESSOR=aarch64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
             result_dir: build
             release_config: Release
           - artifact_name: onnxruntime-osx-x86_64
-            os: macos-12
+            os: macos-11
             build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Darwin CMAKE_SYSTEM_PROCESSOR=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
             result_dir: build
             release_config: Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,13 +111,13 @@ jobs:
             result_dir: build/Release
             release_config: Release-iphoneos
           - artifact_name: onnxruntime-ios-sim-arm64
-            os: macos-11
+            os: macos-12
             build_opts: --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch arm64 --apple_deploy_target 16.0
             build_opts_workaround_protoc: --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc
             result_dir: build/Release
             release_config: Release-iphonesimulator
           - artifact_name: onnxruntime-ios-sim-x86_64
-            os: macos-11
+            os: macos-12
             build_opts: --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch x86_64 --apple_deploy_target 16.0
             build_opts_workaround_protoc: --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc
             result_dir: build/Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,13 +111,13 @@ jobs:
             result_dir: build/Release
             release_config: Release-iphoneos
           - artifact_name: onnxruntime-ios-sim-arm64
-            os: macos-12
+            os: macos-11
             build_opts: --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch arm64 --apple_deploy_target 16.0
             build_opts_workaround_protoc: --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc
             result_dir: build/Release
             release_config: Release-iphonesimulator
           - artifact_name: onnxruntime-ios-sim-x86_64
-            os: macos-12
+            os: macos-11
             build_opts: --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --skip_tests --use_xcode --ios --ios_sysroot iphonesimulator --osx_arch x86_64 --apple_deploy_target 16.0
             build_opts_workaround_protoc: --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc
             result_dir: build/Release


### PR DESCRIPTION
## 内容

iOSではない、macOS用のものを`macos-12`ではなく`macos-11`でビルドするようにします。

## 関連 Issue

## スクリーンショット・動画など

## その他
