### PR TITLE
cuda-toolkitをv0.2.15に上げる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,14 +213,11 @@ jobs:
 
       - name: Set up CUDA
         if: steps.cache-build-result.outputs.cache-hit != 'true' && matrix.cuda_version && matrix.cudnn_url
-        uses: Jimver/cuda-toolkit@v0.2.14
+        uses: Jimver/cuda-toolkit@v0.2.15
         with:
           cuda: ${{ matrix.cuda_version }}
           sub-packages: ${{ matrix.cuda_sub_packages }}
           method: network
-          # https://github.com/Jimver/cuda-toolkit/issues/315#issuecomment-2016310157
-          use-github-cache: ${{ runner.os != 'Windows' }}
-          use-local-cache: ${{ runner.os != 'Windows' }}
 
       - name: Set `$CUDA_HOME`
         if: steps.cache-build-result.outputs.cache-hit != 'true' && matrix.cuda_version && matrix.cudnn_url


### PR DESCRIPTION
## 内容

cuda-toolkitをv0.2.15に上げ、<https://github.com/Jimver/cuda-toolkit/issues/315>に対するワークアラウンドを削除します。

## 関連 Issue

## スクリーンショット・動画など

## その他
