### PR TITLE
add: リリースノートに機械可読な`<table>`を置く

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -509,10 +509,7 @@ jobs:
             cat <<EOF
           ## 動的ライブラリ
 
-          <table
-            data-voicevox-onnxruntime-specs-format-version="1"
-            data-voicevox-onnxruntime-specs-type="dylibs"
-            data-voicevox-onnxruntime-specs-onnxruntime-version="$ONNXRUNTIME_VERSION">
+          <table data-voicevox-onnxruntime-specs-format-version="1" data-voicevox-onnxruntime-specs-type="dylibs">
             <thead>
               <tr>
                 <th>OS</th>
@@ -542,10 +539,7 @@ jobs:
 
           ## XCFramework
 
-          <table
-            data-voicevox-onnxruntime-specs-format-version="1"
-            data-voicevox-onnxruntime-specs-type="xcframeworks"
-            data-voicevox-onnxruntime-specs-onnxruntime-version="$ONNXRUNTIME_VERSION">
+          <table data-voicevox-onnxruntime-specs-format-version="1" data-voicevox-onnxruntime-specs-type="xcframeworks">
             <thead>
               <tr>
                 <th>OS</th>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -340,9 +340,54 @@ jobs:
           path: artifact/*
 
       - name: Generate RELEASE_NAME
-        if: env.RELEASE == 'true'
         run: |
           echo "RELEASE_NAME=${{ matrix.artifact_name }}-${{ env.ONNXRUNTIME_VERSION }}" >> $GITHUB_ENV
+
+      - name: Generate specifications
+        run: |
+          build_opts=(${{ matrix.build_opts }})
+
+          for arg in "${build_opts[@]}"; do
+            case "$arg" in
+              CMAKE_SYSTEM_NAME=Windows) os=Windows ;;
+              CMAKE_SYSTEM_NAME=Linux) os=Linux ;;
+              CMAKE_SYSTEM_NAME=Darwin) os=macOS ;;
+              --android) os=Android ;;
+              --ios) os=iOS ;;
+
+              CMAKE_SYSTEM_PROCESSOR=x86_64 | CMAKE_OSX_ARCHITECTURES=x86_64 | x86_64) arch=x86_64 ;;
+              --x86) arch=x86 ;;
+              CMAKE_OSX_ARCHITECTURES=arm64 | --arm64 | arm64 | arm64-v8a) arch=AArch64 ;;
+              --arm) arch=ARMv7 ;;
+
+              --use_cuda) use_cuda=1 ;;
+              --use_dml) use_dml=1 ;;
+            esac
+          done
+
+          # ONNX Runtimeが示す順番に従う
+          if [ "$use_cuda" = 1 ]; then
+            devices=/CUDA
+          fi
+          if [ "$use_dml" = 1 ]; then
+            devices+=/DirectML
+          fi
+          devices+=/CPU
+          devices=${devices:1}
+
+          specs="<tr>"
+          specs+="<td>$os</td>"
+          specs+="<td>$arch</td>"
+          specs+="<td>$devices</td>"
+          specs+="<td><a href=\"https://github.com/$GITHUB_REPOSITORY/releases/download/$ONNXRUNTIME_VERSION/$RELEASE_NAME.tgz\">$RELEASE_NAME.tgz</a></td>"
+          specs+='</tr>'
+          cat <<< "$specs" > "$RELEASE_NAME.html"
+
+      - name: Upload specifications
+        uses: actions/upload-artifact@v4
+        with:
+          name: specs-${{ matrix.artifact_name }}
+          path: ${{ env.RELEASE_NAME }}.html
 
       - name: Rearchive artifact
         if: env.RELEASE == 'true'
@@ -361,10 +406,15 @@ jobs:
   build-xcframework:
     needs: build-onnxruntime
     runs-on: macos-12
+    outputs:
+      release-name: ${{ steps.gen-envs.outputs.release-name }}
     steps:
       - name: Generate RELEASE_NAME and ONNXRUNTIME_BASENAME
+        id: gen-envs
         run: |
-          echo "RELEASE_NAME=onnxruntime-ios-xcframework-${{ env.ONNXRUNTIME_VERSION }}" >> $GITHUB_ENV
+          RELEASE_NAME=onnxruntime-ios-xcframework-${{ env.ONNXRUNTIME_VERSION }}
+          echo "release-name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
+          echo "RELEASE_NAME=$RELEASE_NAME" >> "$GITHUB_ENV"
           echo "ONNXRUNTIME_BASENAME=libonnxruntime.${{ env.ONNXRUNTIME_VERSION }}.dylib" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@v3
@@ -442,3 +492,76 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.ONNXRUNTIME_VERSION }} # ==> github.event.release.tag_name
           file: ${{ env.RELEASE_NAME }}.zip
+
+  build-spec-table:
+    needs: [build-onnxruntime, build-xcframework]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download specifications
+        uses: actions/download-artifact@v4
+        with:
+          path: specs
+          pattern: specs-*
+          merge-multiple: true
+
+      - name: Construct release notes
+        run: |
+          onnxruntime_version_hyphenated=$(tr . - <<< "$ONNXRUNTIME_VERSION")
+          release_notes=$(
+            cat <<EOF
+          ## 動的ライブラリ
+
+          <table id="voicevox-onnxruntime-specs-v1format-v$onnxruntime_version_hyphenated-dylibs">
+            <thead>
+              <tr>
+                <th>OS</th>
+                <th>ｱｰｷﾃｸﾁｬ</th>
+                <th>デバイス</th>
+                <th>名前</th>
+              </tr>
+            </thead>
+            <tbody>
+          EOF
+          )
+          release_notes+=$'\n'
+          for body in specs/*.html; do
+            release_notes+=$'    '
+            release_notes+=$(< "$body")
+            release_notes+=$'\n'
+          done
+          release_notes+=$(
+            cat <<EOF
+            </tbody>
+          </table>
+
+          ## XCFramework
+
+          <table id="voicevox-onnxruntime-specs-v1format-v$onnxruntime_version_hyphenated-xcframeworks">
+            <thead>
+              <tr>
+                <th>OS</th>
+                <th>アーキテクチャ</th>
+                <th>デバイス</th>
+                <th>名前</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>iOS</td>
+                <td>AArch64/x86_64</td>
+                <td>CPU</td>
+                <td><a href="https://github.com/$GITHUB_REPOSITORY/releases/download/$ONNXRUNTIME_VERSION/${{ needs.build-xcframework.outputs.release-name }}.zip">${{ needs.build-xcframework.outputs.release-name }}.zip</a></td>
+              </tr>
+            </tbody>
+          </table>
+          EOF
+          )
+          tee release-notes.md >&2 <<< "$release_notes"
+
+      - name: Update release notes
+        if: env.RELEASE == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release-notes.md
+          prerelease: true
+          tag_name: ${{ env.ONNXRUNTIME_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -364,29 +364,29 @@ jobs:
             esac
           done
 
-          # ONNX Runtimeが示す順番に従う
-          if [ "$use_cuda" = 1 ]; then
-            devices=/CUDA
-          fi
-          if [ "$use_dml" = 1 ]; then
-            devices+=/DirectML
-          fi
-          devices+=/CPU
-          devices=${devices:1}
-
-          specs="<tr>"
-          specs+="<td>$os</td>"
-          specs+="<td>$arch</td>"
-          specs+="<td>$devices</td>"
-          specs+="<td><a href=\"https://github.com/$GITHUB_REPOSITORY/releases/download/$ONNXRUNTIME_VERSION/$RELEASE_NAME.tgz\">$RELEASE_NAME.tgz</a></td>"
-          specs+='</tr>'
-          cat <<< "$specs" > "$RELEASE_NAME.html"
+          jq '
+            {
+              "os": $os,
+              "arch": $arch,
+              # ONNX Runtimeが示す順番に従う
+              "devices": [
+                ("CUDA" | select($use_cuda == "1")),
+                ("DirectML" | select($use_dml == "1")),
+                "CPU"
+              ] | join("/")
+            }' \
+            -n \
+            --arg os "$os" \
+            --arg arch "$arch" \
+            --arg use_cuda "$use_cuda" \
+            --arg use_dml "$use_dml" \
+            > "$RELEASE_NAME.json"
 
       - name: Upload specifications
         uses: actions/upload-artifact@v4
         with:
           name: specs-${{ matrix.artifact_name }}
-          path: ${{ env.RELEASE_NAME }}.html
+          path: ${{ env.RELEASE_NAME }}.json
 
       - name: Rearchive artifact
         if: env.RELEASE == 'true'
@@ -523,10 +523,15 @@ jobs:
           EOF
           )
           release_notes+=$'\n'
-          for body in specs/*.html; do
-            release_notes+=$'    '
-            release_notes+=$(< "$body")
-            release_notes+=$'\n'
+          for specs_file in specs/*.json; do
+            specs=$(< "$specs_file")
+            release_name=$(basename "${specs_file%.json}")
+            release_notes+=$'    <tr>\n'
+            release_notes+="      <td>$(jq .os -r <<< "$specs")</td>"$'\n'
+            release_notes+="      <td>$(jq .arch -r <<< "$specs")</td>"$'\n'
+            release_notes+="      <td>$(jq .devices -r <<< "$specs")</td>"$'\n'
+            release_notes+="      <td><a href=\"https://github.com/$GITHUB_REPOSITORY/releases/download/$ONNXRUNTIME_VERSION/$release_name.tgz\">$release_name.tgz</a></td>"$'\n'
+            release_notes+=$'    </tr>\n'
           done
           release_notes+=$(
             cat <<EOF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -543,7 +543,7 @@ jobs:
             <thead>
               <tr>
                 <th>OS</th>
-                <th>アーキテクチャ</th>
+                <th>ｱｰｷﾃｸﾁｬ</th>
                 <th>デバイス</th>
                 <th>名前</th>
               </tr>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -505,12 +505,14 @@ jobs:
 
       - name: Construct release notes
         run: |
-          onnxruntime_version_hyphenated=$(tr . - <<< "$ONNXRUNTIME_VERSION")
           release_notes=$(
             cat <<EOF
           ## 動的ライブラリ
 
-          <table id="voicevox-onnxruntime-specs-v1format-v$onnxruntime_version_hyphenated-dylibs">
+          <table
+            data-voicevox-onnxruntime-specs-format-version="1"
+            data-voicevox-onnxruntime-specs-type="dylibs"
+            data-voicevox-onnxruntime-specs-onnxruntime-version="$ONNXRUNTIME_VERSION">
             <thead>
               <tr>
                 <th>OS</th>
@@ -540,7 +542,10 @@ jobs:
 
           ## XCFramework
 
-          <table id="voicevox-onnxruntime-specs-v1format-v$onnxruntime_version_hyphenated-xcframeworks">
+          <table
+            data-voicevox-onnxruntime-specs-format-version="1"
+            data-voicevox-onnxruntime-specs-type="xcframeworks"
+            data-voicevox-onnxruntime-specs-onnxruntime-version="$ONNXRUNTIME_VERSION">
             <thead>
               <tr>
                 <th>OS</th>


### PR DESCRIPTION
## 内容

VOICEVOX/voicevox_core#810 のための変更の一つです。
(VOICEVOX/voicevox_core#810 から依存されているのは、このPRそのものではなく #44 です)

リリースするONNX Runtimeについて機械可読な`<table>`を置き、CORE側のダウンローダーから認識できるようにします。

## 関連 Issue

ref VOICEVOX/voicevox_core#810

## スクリーンショット・動画など

## その他
