### PR TITLE
chore: LinuxのCUDA版にjlumbroso/free-disk-spaceを導入

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,13 @@ jobs:
           path: build/
           key: ${{ matrix.artifact_name }}-v${{ env.ONNXRUNTIME_VERSION }}-cache-${{ hashFiles('matrix.json') }}
 
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        if: steps.cache-build-result.outputs.cache-hit != 'true' && runner.os == 'Linux' && contains(matrix.build_opts, '--use_cuda')
+        with:
+          tool-cache: false
+          large-packages: false
+          swap-storage: false
 
       - name: Install tree
         if: steps.cache-build-result.outputs.cache-hit != 'true' && runner.os == 'Windows'


### PR DESCRIPTION
## 内容

VOICEVOX/voicevox_additional_libraries#4 をやったときのように、LinuxのCUDA版に限りjlumbroso/free-disk-spaceを導入します。

最近になってついに容量が足りなくなり始めたためです。
<https://github.com/qryxip/onnxruntime-builder/actions/runs/10226248892/job/28296262761>

## 関連 Issue

## スクリーンショット・動画など

## その他
