### PR TITLE
remove: CUDAとDirectMLの両方を有効化したビルドは提供しない

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,18 +37,18 @@ jobs:
             build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Windows CMAKE_SYSTEM_PROCESSOR=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
             result_dir: build/Release
             release_config: Release
-          - artifact_name: onnxruntime-win-x64-gpu-cuda
+          - artifact_name: onnxruntime-win-x64-dml
             os: windows-2022
             build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Windows CMAKE_SYSTEM_PROCESSOR=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --use_dml
             result_dir: build/Release
             release_config: Release
-          - artifact_name: onnxruntime-win-x64-gpu
+          - artifact_name: onnxruntime-win-x64-cuda
             os: windows-2022
             cuda_version: 12.4.1
             # Windowsの場合デフォルトのパッケージ群では不十分であるため、必要そうなパッケージを指定する。ただしいくつかは不要かもしれない
             cuda_sub_packages: '["cudart", "cuobjdump", "nvcc", "nvdisasm", "thrust", "cublas_dev", "cufft_dev", "curand_dev", "cusolver_dev", "cusparse_dev", "visual_studio_integration"]'
             cudnn_url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/windows-x86_64/cudnn-windows-x86_64-8.9.7.29_cuda12-archive.zip
-            build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Windows CMAKE_SYSTEM_PROCESSOR=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --use_dml --use_cuda --cuda_version 12.4
+            build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Windows CMAKE_SYSTEM_PROCESSOR=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --use_cuda --cuda_version 12.4
             result_dir: build/Release
             release_config: Release
           - artifact_name: onnxruntime-win-x86
@@ -61,7 +61,7 @@ jobs:
             build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
             result_dir: build
             release_config: Release
-          - artifact_name: onnxruntime-linux-x64-gpu
+          - artifact_name: onnxruntime-linux-x64-cuda
             os: ubuntu-20.04
             cuda_version: 12.4.1
             cuda_sub_packages: "[]" # デフォルト


### PR DESCRIPTION
## 内容

経緯: <https://github.com/VOICEVOX/onnxruntime-builder/issues/46#issuecomment-2290765448>

## 関連 Issue

## スクリーンショット・動画など

## その他
