### PR TITLE
chore: `build_opts`を整理する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -365,10 +365,9 @@ jobs:
       - name: Build ONNX Runtime
         if: steps.cache-build-result.outputs.cache-hit != 'true'
         run: |
+          # TODO: ↓ この記述は VOICEVOX/voicevox_core#41 時点でのarmhfビルドに対するもの。`CMAKE_SYSTEM_{NAME,PROCESSOR}`が必要のないケースが多いはず。例えばv1.17時点では、AndroidとiOSのビルドではcpuinfoのケアまでちゃんとされているはず。
           # add --arm for gcc-8: https://github.com/microsoft/onnxruntime/issues/4189
           # skip test: https://github.com/microsoft/onnxruntime/issues/2436
-          #
-          # TODO: ↓ 今のONNX Runtimeなら別に設定しなくてもいいのではないか？
           # ONNX Runtime v1.9.0 requires CMAKE_SYSTEM_PROCESSOR, https://github.com/microsoft/onnxruntime/releases/tag/v1.9.0
           # Both CMAKE_SYSTEM_NAME and CMAKE_SYSTEM_PROCESSOR are required.
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,15 +31,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TODO: 外せる`--compile_no_warning_as_error`は外す
         include:
           - artifact_name: onnxruntime-win-x64
             os: windows-2022
-            build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Windows CMAKE_SYSTEM_PROCESSOR=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
+            build_opts: |-
+              --compile_no_warning_as_error
+              --cmake_extra_defines
+              CMAKE_SYSTEM_NAME=Windows
+              CMAKE_SYSTEM_PROCESSOR=x86_64
             result_dir: build/Release
             release_config: Release
           - artifact_name: onnxruntime-win-x64-dml
             os: windows-2022
-            build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Windows CMAKE_SYSTEM_PROCESSOR=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --use_dml
+            build_opts: |-
+              --compile_no_warning_as_error
+              --use_dml
+              --cmake_extra_defines
+              CMAKE_SYSTEM_NAME=Windows
+              CMAKE_SYSTEM_PROCESSOR=x86_64
             result_dir: build/Release
             release_config: Release
           - artifact_name: onnxruntime-win-x64-cuda
@@ -48,17 +58,32 @@ jobs:
             # Windowsの場合デフォルトのパッケージ群では不十分であるため、必要そうなパッケージを指定する。ただしいくつかは不要かもしれない
             cuda_sub_packages: '["cudart", "cuobjdump", "nvcc", "nvdisasm", "thrust", "cublas_dev", "cufft_dev", "curand_dev", "cusolver_dev", "cusparse_dev", "visual_studio_integration"]'
             cudnn_url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/windows-x86_64/cudnn-windows-x86_64-8.9.7.29_cuda12-archive.zip
-            build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Windows CMAKE_SYSTEM_PROCESSOR=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --use_cuda --cuda_version 12.4
+            build_opts: |-
+              --compile_no_warning_as_error
+              --use_cuda
+              --cuda_version 12.4 # WindowsではCUDAのディレクトリを見つけ出すのに必要（1.16.3時点）
+              --cmake_extra_defines
+              CMAKE_SYSTEM_NAME=Windows
+              CMAKE_SYSTEM_PROCESSOR=x86_64
             result_dir: build/Release
             release_config: Release
           - artifact_name: onnxruntime-win-x86
             os: windows-2022
-            build_opts: --x86 --cmake_extra_defines CMAKE_SYSTEM_NAME=Windows CMAKE_SYSTEM_PROCESSOR=x86 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
+            build_opts: |-
+              --compile_no_warning_as_error
+              --x86
+              --cmake_extra_defines
+              CMAKE_SYSTEM_NAME=Windows
+              CMAKE_SYSTEM_PROCESSOR=x86
             result_dir: build/Release
             release_config: Release
           - artifact_name: onnxruntime-linux-x64
             os: ubuntu-20.04
-            build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
+            build_opts: |-
+              --compile_no_warning_as_error
+              --cmake_extra_defines
+              CMAKE_SYSTEM_NAME=Linux
+              CMAKE_SYSTEM_PROCESSOR=x86_64
             result_dir: build
             release_config: Release
           - artifact_name: onnxruntime-linux-x64-cuda
@@ -66,7 +91,12 @@ jobs:
             cuda_version: 12.4.1
             cuda_sub_packages: "[]" # デフォルト
             cudnn_url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.9.7.29_cuda12-archive.tar.xz
-            build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --use_cuda
+            build_opts: |-
+              --compile_no_warning_as_error
+              --use_cuda
+              --cmake_extra_defines
+              CMAKE_SYSTEM_NAME=Linux
+              CMAKE_SYSTEM_PROCESSOR=x86_64
             result_dir: build
             release_config: Release
           - artifact_name: onnxruntime-linux-armhf
@@ -75,7 +105,12 @@ jobs:
             cxx_version: "10"
             linux_cross_arch: arm-linux-gnueabihf
             symlink_workaround: true
-            build_opts: --arm --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=armv7l --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
+            build_opts: |-
+              --compile_no_warning_as_error
+              --arm
+              --cmake_extra_defines
+              CMAKE_SYSTEM_NAME=Linux
+              CMAKE_SYSTEM_PROCESSOR=armv7l
             result_dir: build
             release_config: Release
           - artifact_name: onnxruntime-linux-arm64
@@ -84,45 +119,91 @@ jobs:
             cxx_version: "10"
             linux_cross_arch: aarch64-linux-gnu
             symlink_workaround: true
-            build_opts: --arm64 --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux CMAKE_SYSTEM_PROCESSOR=aarch64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
+            build_opts: |-
+              --compile_no_warning_as_error
+              --arm64
+              --cmake_extra_defines
+              CMAKE_SYSTEM_NAME=Linux
+              CMAKE_SYSTEM_PROCESSOR=aarch64
             result_dir: build
             release_config: Release
           - artifact_name: onnxruntime-osx-arm64
             os: macos-12
-            build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Darwin CMAKE_OSX_ARCHITECTURES=arm64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
+            build_opts: |-
+              --compile_no_warning_as_error
+              --cmake_extra_defines
+              CMAKE_SYSTEM_NAME=Darwin
+              CMAKE_OSX_ARCHITECTURES=arm64
             result_dir: build
             release_config: Release
           - artifact_name: onnxruntime-osx-x86_64
             os: macos-12
-            build_opts: --cmake_extra_defines CMAKE_SYSTEM_NAME=Darwin CMAKE_OSX_ARCHITECTURES=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib
+            build_opts: |-
+              --compile_no_warning_as_error
+              --cmake_extra_defines
+              CMAKE_SYSTEM_NAME=Darwin
+              CMAKE_OSX_ARCHITECTURES=x86_64
             result_dir: build
             release_config: Release
           - artifact_name: onnxruntime-android-x64
             os: ubuntu-20.04
-            build_opts: --android_abi x86_64 --cmake_extra_defines CMAKE_SYSTEM_NAME=Android CMAKE_SYSTEM_PROCESSOR=x86_64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --android
+            build_opts: |-
+              --compile_no_warning_as_error
+              --android
+              --android_abi x86_64
+              --cmake_extra_defines
+              CMAKE_SYSTEM_NAME=Android
+              CMAKE_SYSTEM_PROCESSOR=x86_64
             result_dir: build
             release_config: Release
           - artifact_name: onnxruntime-android-arm64
             os: ubuntu-20.04
-            build_opts: --android_abi arm64-v8a --cmake_extra_defines CMAKE_SYSTEM_NAME=Android CMAKE_SYSTEM_PROCESSOR=aarch64 --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --android
+            build_opts: |-
+              --compile_no_warning_as_error
+              --android
+              --android_abi arm64-v8a
+              --cmake_extra_defines
+              CMAKE_SYSTEM_NAME=Android
+              CMAKE_SYSTEM_PROCESSOR=aarch64
             result_dir: build
             release_config: Release
           - artifact_name: onnxruntime-ios-arm64
             os: macos-12
-            build_opts: --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --skip_tests --use_xcode --ios --apple_sysroot iphoneos --osx_arch arm64 --apple_deploy_target 16.0
-            build_opts_workaround_protoc: --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc
+            build_opts: |-
+              --compile_no_warning_as_error
+              --skip_tests
+              --use_xcode
+              --ios
+              --apple_sysroot iphoneos
+              --osx_arch arm64
+              --apple_deploy_target 16.0
+              --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc # https://github.com/VOICEVOX/onnxruntime-builder/issues/23#issuecomment-1599594381
             result_dir: build/Release
             release_config: Release-iphoneos
           - artifact_name: onnxruntime-ios-sim-arm64
             os: macos-12
-            build_opts: --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --skip_tests --use_xcode --ios --apple_sysroot iphonesimulator --osx_arch arm64 --apple_deploy_target 16.0
-            build_opts_workaround_protoc: --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc
+            build_opts: |-
+              --compile_no_warning_as_error
+              --skip_tests
+              --use_xcode
+              --ios
+              --apple_sysroot iphonesimulator
+              --osx_arch arm64
+              --apple_deploy_target 16.0
+              --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc # https://github.com/VOICEVOX/onnxruntime-builder/issues/23#issuecomment-1599594381
             result_dir: build/Release
             release_config: Release-iphonesimulator
           - artifact_name: onnxruntime-ios-sim-x86_64
             os: macos-12
-            build_opts: --config Release --parallel --compile_no_warning_as_error --update --build --build_shared_lib --skip_tests --use_xcode --ios --apple_sysroot iphonesimulator --osx_arch x86_64 --apple_deploy_target 16.0
-            build_opts_workaround_protoc: --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc
+            build_opts: |-
+              --compile_no_warning_as_error
+              --skip_tests
+              --use_xcode
+              --ios
+              --apple_sysroot iphonesimulator
+              --osx_arch x86_64
+              --apple_deploy_target 16.0
+              --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc # https://github.com/VOICEVOX/onnxruntime-builder/issues/23#issuecomment-1599594381
             result_dir: build/Release
             release_config: Release-iphonesimulator
 
@@ -286,9 +367,23 @@ jobs:
         run: |
           # add --arm for gcc-8: https://github.com/microsoft/onnxruntime/issues/4189
           # skip test: https://github.com/microsoft/onnxruntime/issues/2436
+          #
+          # TODO: ↓ 今のONNX Runtimeなら別に設定しなくてもいいのではないか？
           # ONNX Runtime v1.9.0 requires CMAKE_SYSTEM_PROCESSOR, https://github.com/microsoft/onnxruntime/releases/tag/v1.9.0
           # Both CMAKE_SYSTEM_NAME and CMAKE_SYSTEM_PROCESSOR are required.
-          python ./tools/ci_build/build.py --build_dir ./build ${{ matrix.build_opts }} ${{ matrix.build_opts_workaround_protoc }}
+
+          build_opts=(
+          ${{ matrix.build_opts }}
+          )
+
+          python ./tools/ci_build/build.py \
+            --build_dir ./build \
+            --config Release \
+            --update \
+            --build \
+            --parallel \
+            --build_shared_lib \
+            "${build_opts[@]}"
 
       - name: Inspect the build directory for debug
 
@@ -356,7 +451,9 @@ jobs:
 
       - name: Generate specifications
         run: |
-          build_opts=(${{ matrix.build_opts }})
+          build_opts=(
+          ${{ matrix.build_opts }}
+          )
 
           for arg in "${build_opts[@]}"; do
             case "$arg" in

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
               --apple_sysroot iphoneos
               --osx_arch arm64
               --apple_deploy_target 16.0
-              --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc # https://github.com/VOICEVOX/onnxruntime-builder/issues/23#issuecomment-1599594381
+              --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc # Homebrewで入れた`protobuf@21`
             result_dir: build/Release
             release_config: Release-iphoneos
           - artifact_name: onnxruntime-ios-sim-arm64
@@ -190,7 +190,7 @@ jobs:
               --apple_sysroot iphonesimulator
               --osx_arch arm64
               --apple_deploy_target 16.0
-              --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc # https://github.com/VOICEVOX/onnxruntime-builder/issues/23#issuecomment-1599594381
+              --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc # Homebrewで入れた`protobuf@21`
             result_dir: build/Release
             release_config: Release-iphonesimulator
           - artifact_name: onnxruntime-ios-sim-x86_64
@@ -203,7 +203,7 @@ jobs:
               --apple_sysroot iphonesimulator
               --osx_arch x86_64
               --apple_deploy_target 16.0
-              --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc # https://github.com/VOICEVOX/onnxruntime-builder/issues/23#issuecomment-1599594381
+              --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc # Homebrewで入れた`protobuf@21`
             result_dir: build/Release
             release_config: Release-iphonesimulator
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -365,7 +365,7 @@ jobs:
       - name: Build ONNX Runtime
         if: steps.cache-build-result.outputs.cache-hit != 'true'
         run: |
-          # TODO: ↓ この記述は VOICEVOX/voicevox_core#41 時点でのarmhfビルドに対するもの。`CMAKE_SYSTEM_{NAME,PROCESSOR}`が必要のないケースが多いはず。例えばv1.17時点では、AndroidとiOSのビルドではcpuinfoのケアまでちゃんとされているはず。
+          # TODO: ↓ この記述は VOICEVOX/voicevox_core#41 時点でのarmhfビルドに対するもの。`CMAKE_SYSTEM_{NAME,PROCESSOR}`が必要のないケースが多いはず。例えばv1.17時点では、AndroidとiOSのビルドではcpuinfoのケアまでちゃんとされているはず。なので調べる。
           # add --arm for gcc-8: https://github.com/microsoft/onnxruntime/issues/4189
           # skip test: https://github.com/microsoft/onnxruntime/issues/2436
           # ONNX Runtime v1.9.0 requires CMAKE_SYSTEM_PROCESSOR, https://github.com/microsoft/onnxruntime/releases/tag/v1.9.0


### PR DESCRIPTION
## 内容

`build_opts`の整理をします。

1. 全ビルドに共通し、かつ共通し続けるであろうオプションをまとめる
2. YAMLの`|-`を使った複数行の記述方式にし、`#`でコメントも加えられるようにする
    - 実際にいくつかコメントを加える
3. 統一感が出るようにオプションの順番も整える

モチベーションとしては、このリポジトリの秘伝のタレ化を少しでも防ぐためです。

## 関連 Issue

## スクリーンショット・動画など

## その他
