### PR TITLE
add: voicevox_onnxruntimeをビルドできるようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -471,7 +471,8 @@ jobs:
             -F 'payload_json={"username":"onnxruntime-builder"}' \
             -F file1=@${{ matrix.artifact_name }}_stdout.txt \
             -F file2=@${{ matrix.artifact_name }}_stderr.txt \
-            > /dev/null
+            > /dev/null 2>&1
+
         env:
           PRODUCTION_DISCORD_WEBHOOK: ${{ secrets.PRODUCTION_DISCORD_WEBHOOK }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ on:
         options:
           - onnxruntime
           - voicevox_onnxruntime
-
       release:
         description: "リリースするかどうか"
         type: boolean
@@ -22,7 +21,7 @@ on:
 env:
   ONNXRUNTIME_NAME:
     |-
-    ${{ inputs.name || 'onnxruntime' }}
+    ${{ inputs.target || 'onnxruntime' }}
   ONNXRUNTIME_VERSION:
     |- # workflow_dispatchでのバージョン名が入る。無指定なら適当なバージョン
     ${{ github.event.inputs.version || '1.17.3' }}
@@ -41,7 +40,7 @@ jobs:
       matrix:
         # TODO: 外せる`--compile_no_warning_as_error`は外す
         include:
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-win-x64
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-win-x64
             os: windows-2022
             build_opts: |-
               --compile_no_warning_as_error
@@ -51,7 +50,7 @@ jobs:
               Rust_CARGO_TARGET=x86_64-pc-windows-msvc
             result_dir: build/Release
             release_config: Release
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-win-x64-dml
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-win-x64-dml
             os: windows-2022
             build_opts: |-
               --compile_no_warning_as_error
@@ -62,7 +61,7 @@ jobs:
               Rust_CARGO_TARGET=x86_64-pc-windows-msvc
             result_dir: build/Release
             release_config: Release
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-win-x64-cuda
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-win-x64-cuda
             os: windows-2022
             cuda_version: 12.4.1
             # Windowsの場合デフォルトのパッケージ群では不十分であるため、必要そうなパッケージを指定する。ただしいくつかは不要かもしれない
@@ -78,7 +77,7 @@ jobs:
               Rust_CARGO_TARGET=x86_64-pc-windows-msvc
             result_dir: build/Release
             release_config: Release
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-win-x86
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-win-x86
             os: windows-2022
             build_opts: |-
               --compile_no_warning_as_error
@@ -89,7 +88,7 @@ jobs:
               Rust_CARGO_TARGET=i686-pc-windows-msvc
             result_dir: build/Release
             release_config: Release
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-linux-x64
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-linux-x64
             os: ubuntu-20.04
             build_opts: |-
               --compile_no_warning_as_error
@@ -99,7 +98,7 @@ jobs:
               Rust_CARGO_TARGET=x86_64-unknown-linux-gnu
             result_dir: build
             release_config: Release
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-linux-x64-cuda
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-linux-x64-cuda
             os: ubuntu-20.04
             cuda_version: 12.4.1
             cuda_sub_packages: "[]" # デフォルト
@@ -113,7 +112,7 @@ jobs:
               Rust_CARGO_TARGET=x86_64-unknown-linux-gnu
             result_dir: build
             release_config: Release
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-linux-armhf
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-linux-armhf
             os: ubuntu-20.04
             cc_version: "10"
             cxx_version: "10"
@@ -128,7 +127,7 @@ jobs:
               Rust_CARGO_TARGET=armv7-unknown-linux-gnueabihf
             result_dir: build
             release_config: Release
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-linux-arm64
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-linux-arm64
             os: ubuntu-20.04
             cc_version: "10"
             cxx_version: "10"
@@ -143,7 +142,7 @@ jobs:
               Rust_CARGO_TARGET=aarch64-unknown-linux-gnu
             result_dir: build
             release_config: Release
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-osx-arm64
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-osx-arm64
             os: macos-12
             build_opts: |-
               --compile_no_warning_as_error
@@ -153,7 +152,7 @@ jobs:
               Rust_CARGO_TARGET=aarch64-apple-darwin
             result_dir: build
             release_config: Release
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-osx-x86_64
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-osx-x86_64
             os: macos-12
             build_opts: |-
               --compile_no_warning_as_error
@@ -163,7 +162,7 @@ jobs:
               Rust_CARGO_TARGET=x86_64-apple-darwin
             result_dir: build
             release_config: Release
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-android-x64
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-android-x64
             os: ubuntu-20.04
             build_opts: |-
               --compile_no_warning_as_error
@@ -175,7 +174,7 @@ jobs:
               Rust_CARGO_TARGET=x86_64-linux-android
             result_dir: build
             release_config: Release
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-android-arm64
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-android-arm64
             os: ubuntu-20.04
             build_opts: |-
               --compile_no_warning_as_error
@@ -187,7 +186,7 @@ jobs:
               Rust_CARGO_TARGET=aarch64-linux-android
             result_dir: build
             release_config: Release
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-ios-arm64
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-ios-arm64
             os: macos-12
             build_opts: |-
               --compile_no_warning_as_error
@@ -202,7 +201,7 @@ jobs:
               Rust_CARGO_TARGET=aarch64-apple-ios
             result_dir: build/Release
             release_config: Release-iphoneos
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-ios-sim-arm64
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-ios-sim-arm64
             os: macos-12
             build_opts: |-
               --compile_no_warning_as_error
@@ -217,7 +216,7 @@ jobs:
               Rust_CARGO_TARGET=aarch64-apple-ios-sim
             result_dir: build/Release
             release_config: Release-iphonesimulator
-          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-ios-sim-x86_64
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-ios-sim-x86_64
             os: macos-12
             build_opts: |-
               --compile_no_warning_as_error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -473,8 +473,7 @@ jobs:
             -F file2=@${{ matrix.artifact_name }}_stderr.txt \
             > /dev/null
         env:
-          PRODUCTION_DISCORD_WEBHOOK: ${{ secrets.PRODUCTION_DISCORD_WEBHOOK}}
-
+          PRODUCTION_DISCORD_WEBHOOK: ${{ secrets.PRODUCTION_DISCORD_WEBHOOK }}
 
       - name: Inspect the build directory for debug
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,13 +7,14 @@ on:
       version:
         description: "バージョン情報（A.BB.C / A.BB.C-preview.D）"
         required: true
-      name:
-        description: "名前"
+      target:
+        description: "ビルド対象"
         type: choice
         default: onnxruntime
         options:
           - onnxruntime
           - voicevox_onnxruntime
+
       release:
         description: "リリースするかどうか"
         type: boolean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,9 @@ env:
   ONNXRUNTIME_VERSION:
     |- # workflow_dispatchでのバージョン名が入る。無指定なら適当なバージョン
     ${{ inputs.version || '1.17.3' }}
-
   RELEASE:
     |- # workflow_dispatchでのreleaseフラグがあればリリースする
-    ${{ github.event.inputs.release == 'true' }}
+    ${{ inputs.release == 'true' }}
 
 defaults:
   run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -466,14 +466,15 @@ jobs:
         if: failure() && steps.build.outcome == 'failure' && env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
         run: |
           curl \
-            "$DISCORD_WEBHOOK" \
+            "$PRODUCTION_DISCORD_WEBHOOK" \
             -sf \
             -F 'payload_json={"username":"onnxruntime-builder"}' \
             -F file1=@${{ matrix.artifact_name }}_stdout.txt \
             -F file2=@${{ matrix.artifact_name }}_stderr.txt \
             > /dev/null
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          PRODUCTION_DISCORD_WEBHOOK: ${{ secrets.PRODUCTION_DISCORD_WEBHOOK}}
+
 
       - name: Inspect the build directory for debug
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ env:
     ${{ inputs.target || 'onnxruntime' }}
   ONNXRUNTIME_VERSION:
     |- # workflow_dispatchでのバージョン名が入る。無指定なら適当なバージョン
-    ${{ github.event.inputs.version || '1.17.3' }}
+    ${{ inputs.version || '1.17.3' }}
+
   RELEASE:
     |- # workflow_dispatchでのreleaseフラグがあればリリースする
     ${{ github.event.inputs.release == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ on:
         default: false
 
 env:
-  ONNXRUNTIME_NAME:
+  TARGET_LIBRARY:
     |-
     ${{ inputs.target || 'onnxruntime' }}
   ONNXRUNTIME_VERSION:
@@ -263,7 +263,7 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
-        if: env.ONNXRUNTIME_NAME == 'onnxruntime'
+        if: env.TARGET_LIBRARY == 'onnxruntime'
         with:
           repository: microsoft/onnxruntime
           submodules: true
@@ -271,7 +271,7 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
-        if: env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        if: env.TARGET_LIBRARY == 'voicevox_onnxruntime'
         with:
           repository: microsoft/onnxruntime
           submodules: true
@@ -279,7 +279,7 @@ jobs:
           token: ${{ secrets.PRODUCTION_GITHUB_TOKEN }}
 
       - name: Switch to production
-        if: env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        if: env.TARGET_LIBRARY == 'voicevox_onnxruntime'
         run: |
           (
             git remote add private "$PRODUCTION_REPOSITORY_URL"
@@ -393,7 +393,7 @@ jobs:
 
       - name: Extract Rust toolchain and target triple
         id: rust-toolchain-and-target-triple
-        if: steps.cache-build-result.outputs.cache-hit != 'true' && env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        if: steps.cache-build-result.outputs.cache-hit != 'true' && env.TARGET_LIBRARY == 'voicevox_onnxruntime'
         run: |
           build_opts=(
           ${{ matrix.build_opts }}
@@ -402,18 +402,18 @@ jobs:
           echo "target=$(sed -E 's/.*Rust_CARGO_TARGET=([a-z0-9_-]+).*/\1/' <<< "${build_opts[*]}")" >> "$GITHUB_OUTPUT"
 
       - name: Set up Rust
-        if: steps.cache-build-result.outputs.cache-hit != 'true' && env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        if: steps.cache-build-result.outputs.cache-hit != 'true' && env.TARGET_LIBRARY == 'voicevox_onnxruntime'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.rust-toolchain-and-target-triple.outputs.toolchain }}
           targets: ${{ steps.rust-toolchain-and-target-triple.outputs.target }}
 
       - name: Install cargo-binstall
-        if: steps.cache-build-result.outputs.cache-hit != 'true' && env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        if: steps.cache-build-result.outputs.cache-hit != 'true' && env.TARGET_LIBRARY == 'voicevox_onnxruntime'
         uses: taiki-e/install-action@cargo-binstall
 
       - name: Install cxxbridge-cmd
-        if: steps.cache-build-result.outputs.cache-hit != 'true' && env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        if: steps.cache-build-result.outputs.cache-hit != 'true' && env.TARGET_LIBRARY == 'voicevox_onnxruntime'
         run: |
           md=$(cargo metadata --manifest-path ./vv_bin/Cargo.toml --format-version 1)
           version=$(jq -r '.packages[] | select(.name == "cxx").version' <<< "$md")
@@ -465,11 +465,11 @@ jobs:
             --parallel \
             --build_shared_lib \
             "${build_opts[@]}" \
-            1>${{ env.ONNXRUNTIME_NAME == 'onnxruntime' && '&1' || format('{0}_stdout.txt', matrix.artifact_name) }} \
-            2>${{ env.ONNXRUNTIME_NAME == 'onnxruntime' && '&2' || format('{0}_stderr.txt', matrix.artifact_name) }}
+            1>${{ env.TARGET_LIBRARY == 'onnxruntime' && '&1' || format('{0}_stdout.txt', matrix.artifact_name) }} \
+            2>${{ env.TARGET_LIBRARY == 'onnxruntime' && '&2' || format('{0}_stderr.txt', matrix.artifact_name) }}
 
       - name: Send build log to Discord
-        if: failure() && steps.build.outcome == 'failure' && env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        if: failure() && steps.build.outcome == 'failure' && env.TARGET_LIBRARY == 'voicevox_onnxruntime'
         run: |
           curl \
             "$PRODUCTION_DISCORD_WEBHOOK" \
@@ -499,15 +499,15 @@ jobs:
           rm -rf ./artifact
           # Set library name
           ARTIFACT_NAME=${{ matrix.artifact_name }}
-          if [[ "$ARTIFACT_NAME" == "$ONNXRUNTIME_NAME"-win-* ]]; then
+          if [[ "$ARTIFACT_NAME" == "$TARGET_LIBRARY"-win-* ]]; then
             # FIXME: この分岐はもう使わないのでは?
-            onnxruntime_filename=$ONNXRUNTIME_NAME.dll
-          elif [[ "$ARTIFACT_NAME" == "$ONNXRUNTIME_NAME"-linux-* ]]; then
-            onnxruntime_filename="lib$ONNXRUNTIME_NAME.so.$ONNXRUNTIME_VERSION"
-          elif [[ "$ARTIFACT_NAME" == "$ONNXRUNTIME_NAME"-android-* ]]; then
-            onnxruntime_filename="lib$ONNXRUNTIME_NAME.so"
-          elif [[ "$ARTIFACT_NAME" == "$ONNXRUNTIME_NAME"-osx-* ]] || [[ "$ARTIFACT_NAME" == "$ONNXRUNTIME_NAME"-ios-* ]]; then
-            onnxruntime_filename="lib$ONNXRUNTIME_NAME.$ONNXRUNTIME_VERSION.dylib"
+            onnxruntime_filename=$TARGET_LIBRARY.dll
+          elif [[ "$ARTIFACT_NAME" == "$TARGET_LIBRARY"-linux-* ]]; then
+            onnxruntime_filename="lib$TARGET_LIBRARY.so.$ONNXRUNTIME_VERSION"
+          elif [[ "$ARTIFACT_NAME" == "$TARGET_LIBRARY"-android-* ]]; then
+            onnxruntime_filename="lib$TARGET_LIBRARY.so"
+          elif [[ "$ARTIFACT_NAME" == "$TARGET_LIBRARY"-osx-* ]] || [[ "$ARTIFACT_NAME" == "$TARGET_LIBRARY"-ios-* ]]; then
+            onnxruntime_filename="lib$TARGET_LIBRARY.$ONNXRUNTIME_VERSION.dylib"
           else
             echo "Unknown target found : ${{ matrix.artifact_name }}"
             return 1
@@ -519,10 +519,10 @@ jobs:
             git rev-parse HEAD > ./${{ matrix.result_dir }}/${{ matrix.artifact_name }}/GIT_COMMIT_ID
             cp ./{LICENSE,README.md,ThirdPartyNotices.txt,VERSION_NUMBER} \
               ./${{ matrix.result_dir }}/${{ matrix.artifact_name }}/
-            cp ./${{ matrix.result_dir }}/${{ matrix.release_config }}/"$ONNXRUNTIME_NAME".{dll,lib} \
+            cp ./${{ matrix.result_dir }}/${{ matrix.release_config }}/"$TARGET_LIBRARY".{dll,lib} \
               ./${{ matrix.result_dir }}/${{ matrix.artifact_name }}/lib/
-            if [ -f ./${{ matrix.result_dir }}/${{ matrix.release_config }}/"$ONNXRUNTIME_NAME"_providers_cuda.dll ]; then
-              cp ./${{ matrix.result_dir }}/${{ matrix.release_config }}/"$ONNXRUNTIME_NAME"_providers_{cuda,shared}.{dll,lib} \
+            if [ -f ./${{ matrix.result_dir }}/${{ matrix.release_config }}/"$TARGET_LIBRARY"_providers_cuda.dll ]; then
+              cp ./${{ matrix.result_dir }}/${{ matrix.release_config }}/"$TARGET_LIBRARY"_providers_{cuda,shared}.{dll,lib} \
                 ./${{ matrix.result_dir }}/${{ matrix.artifact_name }}/lib/
             fi
           else
@@ -535,7 +535,7 @@ jobs:
               -t "$(git rev-parse HEAD)"
             rm -r ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/{Privacy.md,include}
           fi
-          if [ "$ONNXRUNTIME_NAME" = voicevox_onnxruntime ]; then
+          if [ "$TARGET_LIBRARY" = voicevox_onnxruntime ]; then
             mv ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/{,ORT_}LICENSE
             mv ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/{,ORT_}README.md
             mv ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/{,Ort}ThirdPartyNotices.txt
@@ -620,7 +620,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.ONNXRUNTIME_NAME }}-${{ env.ONNXRUNTIME_VERSION }}
+          tag: ${{ env.TARGET_LIBRARY }}-${{ env.ONNXRUNTIME_VERSION }}
           file: ${{ env.RELEASE_NAME }}.tgz
 
   build-xcframework:
@@ -632,36 +632,36 @@ jobs:
       - name: Generate RELEASE_NAME and ONNXRUNTIME_BASENAME
         id: gen-envs
         run: |
-          RELEASE_NAME=$ONNXRUNTIME_NAME-ios-xcframework-$ONNXRUNTIME_VERSION
+          RELEASE_NAME=$TARGET_LIBRARY-ios-xcframework-$ONNXRUNTIME_VERSION
           echo "release-name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
           echo "RELEASE_NAME=$RELEASE_NAME" >> "$GITHUB_ENV"
-          echo "ONNXRUNTIME_BASENAME=lib$ONNXRUNTIME_NAME.$ONNXRUNTIME_VERSION.dylib" >> "$GITHUB_ENV"
+          echo "ONNXRUNTIME_BASENAME=lib$TARGET_LIBRARY.$ONNXRUNTIME_VERSION.dylib" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ONNXRUNTIME_NAME }}-ios-arm64
-          path: artifact/${{ env.ONNXRUNTIME_NAME }}-aarch64-apple-ios
+          name: ${{ env.TARGET_LIBRARY }}-ios-arm64
+          path: artifact/${{ env.TARGET_LIBRARY }}-aarch64-apple-ios
 
       - uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ONNXRUNTIME_NAME }}-ios-sim-arm64
-          path: artifact/${{ env.ONNXRUNTIME_NAME }}-aarch64-apple-ios-sim
+          name: ${{ env.TARGET_LIBRARY }}-ios-sim-arm64
+          path: artifact/${{ env.TARGET_LIBRARY }}-aarch64-apple-ios-sim
 
       - uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ONNXRUNTIME_NAME }}-ios-sim-x86_64
-          path: artifact/${{ env.ONNXRUNTIME_NAME }}-x86_64-apple-ios
+          name: ${{ env.TARGET_LIBRARY }}-ios-sim-x86_64
+          path: artifact/${{ env.TARGET_LIBRARY }}-x86_64-apple-ios
 
       - name: Remove no version notation dylib
         run: |
-          rm -f artifact/"$ONNXRUNTIME_NAME"-x86_64-apple-ios/lib/*"$ONNXRUNTIME_NAME".dylib
-          rm -f artifact/"$ONNXRUNTIME_NAME"-aarch64-apple-ios-sim/lib/*"$ONNXRUNTIME_NAME".dylib
-          rm -f artifact/"$ONNXRUNTIME_NAME"-aarch64-apple-ios/lib/*"$ONNXRUNTIME_NAME".dylib
+          rm -f artifact/"$TARGET_LIBRARY"-x86_64-apple-ios/lib/*"$TARGET_LIBRARY".dylib
+          rm -f artifact/"$TARGET_LIBRARY"-aarch64-apple-ios-sim/lib/*"$TARGET_LIBRARY".dylib
+          rm -f artifact/"$TARGET_LIBRARY"-aarch64-apple-ios/lib/*"$TARGET_LIBRARY".dylib
 
       - name: '"onnxruntime" → "voicevox_onnxruntime"'
-        if: env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        if: env.TARGET_LIBRARY == 'voicevox_onnxruntime'
         run: |
           for arch in aarch64 sim; do
             mv xcframework/Frameworks/$arch/{,voicevox_}onnxruntime.framework
@@ -673,52 +673,52 @@ jobs:
           mkdir -p "Framework-aarch64"
           cp -vr xcframework/Frameworks/aarch64/ Framework-aarch64/
 
-          lipo -create "artifact/$ONNXRUNTIME_NAME-aarch64-apple-ios/lib/$ONNXRUNTIME_BASENAME" \
-            -output "Framework-aarch64/$ONNXRUNTIME_NAME.framework/$ONNXRUNTIME_NAME"
+          lipo -create "artifact/$TARGET_LIBRARY-aarch64-apple-ios/lib/$ONNXRUNTIME_BASENAME" \
+            -output "Framework-aarch64/$TARGET_LIBRARY.framework/$TARGET_LIBRARY"
 
       - name: Change aarch64 @rpath
         run: |
-          install_name_tool -id "@rpath/$ONNXRUNTIME_NAME.framework/$ONNXRUNTIME_NAME" \
-            "Framework-aarch64/$ONNXRUNTIME_NAME.framework/$ONNXRUNTIME_NAME"
+          install_name_tool -id "@rpath/$TARGET_LIBRARY.framework/$TARGET_LIBRARY" \
+            "Framework-aarch64/$TARGET_LIBRARY.framework/$TARGET_LIBRARY"
 
       - name: Create fat binary
         run: |
-          mkdir -p "artifact/$ONNXRUNTIME_NAME-sim"
-          lipo -create "artifact/$ONNXRUNTIME_NAME-x86_64-apple-ios/lib/$ONNXRUNTIME_BASENAME" \
-            "artifact/$ONNXRUNTIME_NAME-aarch64-apple-ios-sim/lib/$ONNXRUNTIME_BASENAME" \
-            -output "artifact/$ONNXRUNTIME_NAME-sim/$ONNXRUNTIME_NAME"
+          mkdir -p "artifact/$TARGET_LIBRARY-sim"
+          lipo -create "artifact/$TARGET_LIBRARY-x86_64-apple-ios/lib/$ONNXRUNTIME_BASENAME" \
+            "artifact/$TARGET_LIBRARY-aarch64-apple-ios-sim/lib/$ONNXRUNTIME_BASENAME" \
+            -output "artifact/$TARGET_LIBRARY-sim/$TARGET_LIBRARY"
 
       - name: Create sim Framework
         run: |
           mkdir -p "Framework-sim"
           cp -vr xcframework/Frameworks/sim/ Framework-sim/
-          cp -v "artifact/$ONNXRUNTIME_NAME-sim/$ONNXRUNTIME_NAME" \
-            "Framework-sim/$ONNXRUNTIME_NAME.framework/$ONNXRUNTIME_NAME"
+          cp -v "artifact/$TARGET_LIBRARY-sim/$TARGET_LIBRARY" \
+            "Framework-sim/$TARGET_LIBRARY.framework/$TARGET_LIBRARY"
 
       - name: Change sim @rpath
         run: |
-          install_name_tool -id "@rpath/$ONNXRUNTIME_NAME.framework/$ONNXRUNTIME_NAME" \
-            "Framework-sim/$ONNXRUNTIME_NAME.framework/$ONNXRUNTIME_NAME"
+          install_name_tool -id "@rpath/$TARGET_LIBRARY.framework/$TARGET_LIBRARY" \
+            "Framework-sim/$TARGET_LIBRARY.framework/$TARGET_LIBRARY"
 
       - name: Create XCFramework
         run: |
           mkdir -p "artifact/$ONNXRUNTIME_BASENAME"
           xcodebuild -create-xcframework \
-            -framework "Framework-sim/$ONNXRUNTIME_NAME.framework" \
-            -framework "Framework-aarch64/$ONNXRUNTIME_NAME.framework" \
-            -output "artifact/$ONNXRUNTIME_BASENAME/$ONNXRUNTIME_NAME.xcframework"
+            -framework "Framework-sim/$TARGET_LIBRARY.framework" \
+            -framework "Framework-aarch64/$TARGET_LIBRARY.framework" \
+            -output "artifact/$ONNXRUNTIME_BASENAME/$TARGET_LIBRARY.xcframework"
 
       - name: Archive artifact
         run: |
           cd "artifact/$ONNXRUNTIME_BASENAME"
-          7z a "../../$RELEASE_NAME.zip" "$ONNXRUNTIME_NAME.xcframework"
+          7z a "../../$RELEASE_NAME.zip" "$TARGET_LIBRARY.xcframework"
 
       - name: Upload to Release
         if: env.RELEASE == 'true'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.ONNXRUNTIME_NAME }}-${{ env.ONNXRUNTIME_VERSION }}
+          tag: ${{ env.TARGET_LIBRARY }}-${{ env.ONNXRUNTIME_VERSION }}
           file: ${{ env.RELEASE_NAME }}.zip
 
   build-spec-table:
@@ -758,7 +758,7 @@ jobs:
             release_notes+="      <td>$(jq .os -r <<< "$specs")</td>"$'\n'
             release_notes+="      <td>$(jq .arch -r <<< "$specs")</td>"$'\n'
             release_notes+="      <td>$(jq .devices -r <<< "$specs")</td>"$'\n'
-            release_notes+="      <td><a href=\"https://github.com/$GITHUB_REPOSITORY/releases/download/$ONNXRUNTIME_NAME-$ONNXRUNTIME_VERSION/$release_name.tgz\">$release_name.tgz</a></td>"$'\n'
+            release_notes+="      <td><a href=\"https://github.com/$GITHUB_REPOSITORY/releases/download/$TARGET_LIBRARY-$ONNXRUNTIME_VERSION/$release_name.tgz\">$release_name.tgz</a></td>"$'\n'
             release_notes+=$'    </tr>\n'
           done
           release_notes+=$(
@@ -782,7 +782,7 @@ jobs:
                 <td>iOS</td>
                 <td>AArch64/x86_64</td>
                 <td>CPU</td>
-                <td><a href="https://github.com/$GITHUB_REPOSITORY/releases/download/$ONNXRUNTIME_NAME-$ONNXRUNTIME_VERSION/${{ needs.build-xcframework.outputs.release-name }}.zip">${{ needs.build-xcframework.outputs.release-name }}.zip</a></td>
+                <td><a href="https://github.com/$GITHUB_REPOSITORY/releases/download/$TARGET_LIBRARY-$ONNXRUNTIME_VERSION/${{ needs.build-xcframework.outputs.release-name }}.zip">${{ needs.build-xcframework.outputs.release-name }}.zip</a></td>
               </tr>
             </tbody>
           </table>
@@ -796,4 +796,4 @@ jobs:
         with:
           body_path: release-notes.md
           prerelease: true
-          tag_name: ${{ env.ONNXRUNTIME_NAME }}-${{ env.ONNXRUNTIME_VERSION }}
+          tag_name: ${{ env.TARGET_LIBRARY }}-${{ env.ONNXRUNTIME_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,7 +278,7 @@ jobs:
           (
             git remote add private "$PRODUCTION_REPOSITORY_URL"
             git fetch private "refs/tags/v$ONNXRUNTIME_VERSION-voicevox"
-            git -c user.name=dummy -c user.email=dummy@dummy.dummy switch -d FETCH_HEAD
+            git switch -d FETCH_HEAD
           ) > /dev/null 2>&1
         env:
           PRODUCTION_REPOSITORY_URL: ${{ secrets.PRODUCTION_REPOSITORY_URL }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,25 +2,32 @@ name: Build C++ Shared Library
 
 on:
   push:
-  release:
-    types:
-      - published
   workflow_dispatch:
     inputs:
       version:
         description: "バージョン情報（A.BB.C / A.BB.C-preview.D）"
         required: true
+      name:
+        description: "名前"
+        type: choice
+        default: onnxruntime
+        options:
+          - onnxruntime
+          - voicevox_onnxruntime
       release:
         description: "リリースするかどうか"
         type: boolean
 
 env:
+  ONNXRUNTIME_NAME:
+    |-
+    ${{ inputs.name || 'onnxruntime' }}
   ONNXRUNTIME_VERSION:
-    |- # releaseタグ名か、workflow_dispatchでのバージョン名が入る。無指定なら適当なバージョン
-    ${{ github.event.release.tag_name || github.event.inputs.version || '1.17.3' }}
+    |- # workflow_dispatchでのバージョン名が入る。無指定なら適当なバージョン
+    ${{ github.event.inputs.version || '1.17.3' }}
   RELEASE:
-    |- # releaseタグ名か、workflow_dispatchでのreleaseフラグがあればリリースする
-    ${{ github.event.release.tag_name != '' || github.event.inputs.release == 'true' }}
+    |- # workflow_dispatchでのreleaseフラグがあればリリースする
+    ${{ github.event.inputs.release == 'true' }}
 
 defaults:
   run:
@@ -33,16 +40,17 @@ jobs:
       matrix:
         # TODO: 外せる`--compile_no_warning_as_error`は外す
         include:
-          - artifact_name: onnxruntime-win-x64
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-win-x64
             os: windows-2022
             build_opts: |-
               --compile_no_warning_as_error
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Windows
               CMAKE_SYSTEM_PROCESSOR=x86_64
+              Rust_CARGO_TARGET=x86_64-pc-windows-msvc
             result_dir: build/Release
             release_config: Release
-          - artifact_name: onnxruntime-win-x64-dml
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-win-x64-dml
             os: windows-2022
             build_opts: |-
               --compile_no_warning_as_error
@@ -50,9 +58,10 @@ jobs:
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Windows
               CMAKE_SYSTEM_PROCESSOR=x86_64
+              Rust_CARGO_TARGET=x86_64-pc-windows-msvc
             result_dir: build/Release
             release_config: Release
-          - artifact_name: onnxruntime-win-x64-cuda
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-win-x64-cuda
             os: windows-2022
             cuda_version: 12.4.1
             # Windowsの場合デフォルトのパッケージ群では不十分であるため、必要そうなパッケージを指定する。ただしいくつかは不要かもしれない
@@ -65,9 +74,10 @@ jobs:
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Windows
               CMAKE_SYSTEM_PROCESSOR=x86_64
+              Rust_CARGO_TARGET=x86_64-pc-windows-msvc
             result_dir: build/Release
             release_config: Release
-          - artifact_name: onnxruntime-win-x86
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-win-x86
             os: windows-2022
             build_opts: |-
               --compile_no_warning_as_error
@@ -75,18 +85,20 @@ jobs:
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Windows
               CMAKE_SYSTEM_PROCESSOR=x86
+              Rust_CARGO_TARGET=i686-pc-windows-msvc
             result_dir: build/Release
             release_config: Release
-          - artifact_name: onnxruntime-linux-x64
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-linux-x64
             os: ubuntu-20.04
             build_opts: |-
               --compile_no_warning_as_error
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Linux
               CMAKE_SYSTEM_PROCESSOR=x86_64
+              Rust_CARGO_TARGET=x86_64-unknown-linux-gnu
             result_dir: build
             release_config: Release
-          - artifact_name: onnxruntime-linux-x64-cuda
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-linux-x64-cuda
             os: ubuntu-20.04
             cuda_version: 12.4.1
             cuda_sub_packages: "[]" # デフォルト
@@ -97,9 +109,10 @@ jobs:
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Linux
               CMAKE_SYSTEM_PROCESSOR=x86_64
+              Rust_CARGO_TARGET=x86_64-unknown-linux-gnu
             result_dir: build
             release_config: Release
-          - artifact_name: onnxruntime-linux-armhf
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-linux-armhf
             os: ubuntu-20.04
             cc_version: "10"
             cxx_version: "10"
@@ -111,9 +124,10 @@ jobs:
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Linux
               CMAKE_SYSTEM_PROCESSOR=armv7l
+              Rust_CARGO_TARGET=armv7-unknown-linux-gnueabihf
             result_dir: build
             release_config: Release
-          - artifact_name: onnxruntime-linux-arm64
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-linux-arm64
             os: ubuntu-20.04
             cc_version: "10"
             cxx_version: "10"
@@ -125,27 +139,30 @@ jobs:
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Linux
               CMAKE_SYSTEM_PROCESSOR=aarch64
+              Rust_CARGO_TARGET=aarch64-unknown-linux-gnu
             result_dir: build
             release_config: Release
-          - artifact_name: onnxruntime-osx-arm64
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-osx-arm64
             os: macos-12
             build_opts: |-
               --compile_no_warning_as_error
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Darwin
               CMAKE_OSX_ARCHITECTURES=arm64
+              Rust_CARGO_TARGET=aarch64-apple-darwin
             result_dir: build
             release_config: Release
-          - artifact_name: onnxruntime-osx-x86_64
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-osx-x86_64
             os: macos-12
             build_opts: |-
               --compile_no_warning_as_error
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Darwin
               CMAKE_OSX_ARCHITECTURES=x86_64
+              Rust_CARGO_TARGET=x86_64-apple-darwin
             result_dir: build
             release_config: Release
-          - artifact_name: onnxruntime-android-x64
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-android-x64
             os: ubuntu-20.04
             build_opts: |-
               --compile_no_warning_as_error
@@ -154,9 +171,10 @@ jobs:
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Android
               CMAKE_SYSTEM_PROCESSOR=x86_64
+              Rust_CARGO_TARGET=x86_64-linux-android
             result_dir: build
             release_config: Release
-          - artifact_name: onnxruntime-android-arm64
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-android-arm64
             os: ubuntu-20.04
             build_opts: |-
               --compile_no_warning_as_error
@@ -165,9 +183,10 @@ jobs:
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Android
               CMAKE_SYSTEM_PROCESSOR=aarch64
+              Rust_CARGO_TARGET=aarch64-linux-android
             result_dir: build
             release_config: Release
-          - artifact_name: onnxruntime-ios-arm64
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-ios-arm64
             os: macos-12
             build_opts: |-
               --compile_no_warning_as_error
@@ -178,9 +197,11 @@ jobs:
               --osx_arch arm64
               --apple_deploy_target 16.0
               --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc # Homebrewで入れた`protobuf@21`
+              --cmake_extra_defines
+              Rust_CARGO_TARGET=aarch64-apple-ios
             result_dir: build/Release
             release_config: Release-iphoneos
-          - artifact_name: onnxruntime-ios-sim-arm64
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-ios-sim-arm64
             os: macos-12
             build_opts: |-
               --compile_no_warning_as_error
@@ -191,9 +212,11 @@ jobs:
               --osx_arch arm64
               --apple_deploy_target 16.0
               --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc # Homebrewで入れた`protobuf@21`
+              --cmake_extra_defines
+              Rust_CARGO_TARGET=aarch64-apple-ios-sim
             result_dir: build/Release
             release_config: Release-iphonesimulator
-          - artifact_name: onnxruntime-ios-sim-x86_64
+          - artifact_name: ${{ inputs.name || 'onnxruntime' }}-ios-sim-x86_64
             os: macos-12
             build_opts: |-
               --compile_no_warning_as_error
@@ -204,6 +227,8 @@ jobs:
               --osx_arch x86_64
               --apple_deploy_target 16.0
               --path_to_protoc_exe /usr/local/opt/protobuf@21/bin/protoc # Homebrewで入れた`protobuf@21`
+              --cmake_extra_defines
+              Rust_CARGO_TARGET=x86_64-apple-ios
             result_dir: build/Release
             release_config: Release-iphonesimulator
 
@@ -232,10 +257,32 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        if: env.ONNXRUNTIME_NAME == 'onnxruntime'
         with:
           repository: microsoft/onnxruntime
           submodules: true
           ref: v${{ env.ONNXRUNTIME_VERSION }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        with:
+          repository: microsoft/onnxruntime
+          submodules: true
+          ref: v${{ env.ONNXRUNTIME_VERSION }}
+          token: ${{ secrets.PRODUCTION_GITHUB_TOKEN }}
+
+      - name: Switch to production
+        if: env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        run: |
+          (
+            git remote add private "$PRODUCTION_REPOSITORY_URL"
+            git fetch private "refs/tags/v$ONNXRUNTIME_VERSION-voicevox"
+            git -c user.name=dummy -c user.email=dummy@dummy.dummy switch -d FETCH_HEAD
+          ) > /dev/null 2>&1
+        env:
+          PRODUCTION_REPOSITORY_URL: ${{ secrets.PRODUCTION_REPOSITORY_URL }}
+
       - name: Checkout builder
         uses: actions/checkout@v4
         with:
@@ -338,6 +385,34 @@ jobs:
 
           echo "CUDNN_HOME=$cudnn_path" >> "$GITHUB_ENV"
 
+      - name: Extract Rust toolchain and target triple
+        id: rust-toolchain-and-target-triple
+        if: steps.cache-build-result.outputs.cache-hit != 'true' && env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        run: |
+          build_opts=(
+          ${{ matrix.build_opts }}
+          )
+          echo "toolchain=$(cat ./rust-toolchain)" >> "$GITHUB_OUTPUT"
+          echo "target=$(sed -E 's/.*Rust_CARGO_TARGET=([a-z0-9_-]+).*/\1/' <<< "${build_opts[*]}")" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Rust
+        if: steps.cache-build-result.outputs.cache-hit != 'true' && env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust-toolchain-and-target-triple.outputs.toolchain }}
+          targets: ${{ steps.rust-toolchain-and-target-triple.outputs.target }}
+
+      - name: Install cargo-binstall
+        if: steps.cache-build-result.outputs.cache-hit != 'true' && env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        uses: taiki-e/install-action@cargo-binstall
+
+      - name: Install cxxbridge-cmd
+        if: steps.cache-build-result.outputs.cache-hit != 'true' && env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        run: |
+          md=$(cargo metadata --manifest-path ./decrypt_vv_model/Cargo.toml --format-version 1)
+          version=$(jq -r '.packages[] | select(.name == "cxx").version' <<< "$md")
+          cargo binstall "cxxbridge-cmd@$version" --no-confirm --log-level debug
+
       - name: Configure build environment for non-x86_64 Linux
         if: steps.cache-build-result.outputs.cache-hit != 'true' && startsWith(matrix.os, 'ubuntu') && matrix.linux_cross_arch
         run: |
@@ -357,12 +432,13 @@ jobs:
           echo "CXX=${{ env.ARCH_PREFIX }}g++-${{ matrix.cxx_version }}" >> "$GITHUB_ENV"
 
       - name: Configure to use latest Android NDK
-        if: steps.cache-build-result.outputs.cache-hit != 'true' && startsWith(matrix.os, 'ubuntu') && startsWith(matrix.artifact_name, 'onnxruntime-android')
+        if: steps.cache-build-result.outputs.cache-hit != 'true' && startsWith(matrix.os, 'ubuntu') && contains(matrix.build_opts, '--android')
         run: |
           # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md#environment-variables-2
           echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> "$GITHUB_ENV"
 
       - name: Build ONNX Runtime
+        id: build
         if: steps.cache-build-result.outputs.cache-hit != 'true'
         run: |
           # TODO: ↓ この記述は VOICEVOX/voicevox_core#41 時点でのarmhfビルドに対するもの。`CMAKE_SYSTEM_{NAME,PROCESSOR}`が必要のないケースが多いはず。例えばv1.17時点では、AndroidとiOSのビルドではcpuinfoのケアまでちゃんとされているはず。なので調べる。
@@ -382,7 +458,22 @@ jobs:
             --build \
             --parallel \
             --build_shared_lib \
-            "${build_opts[@]}"
+            "${build_opts[@]}" \
+            1>${{ env.ONNXRUNTIME_NAME == 'onnxruntime' && '&1' || format('{0}_stdout.txt', matrix.artifact_name) }} \
+            2>${{ env.ONNXRUNTIME_NAME == 'onnxruntime' && '&2' || format('{0}_stderr.txt', matrix.artifact_name) }}
+
+      - name: Send build log to Discord
+        if: failure() && steps.build.outcome == 'failure' && env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        run: |
+          curl \
+            "$DISCORD_WEBHOOK" \
+            -sf \
+            -F 'payload_json={"username":"onnxruntime-builder"}' \
+            -F file1=@${{ matrix.artifact_name }}_stdout.txt \
+            -F file2=@${{ matrix.artifact_name }}_stderr.txt \
+            > /dev/null
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
 
       - name: Inspect the build directory for debug
 
@@ -402,14 +493,15 @@ jobs:
           rm -rf ./artifact
           # Set library name
           ARTIFACT_NAME=${{ matrix.artifact_name }}
-          if [[ "$ARTIFACT_NAME" == onnxruntime-win-* ]]; then
-            ONNXRUNTIME_NAME=onnxruntime.dll
-          elif [[ "$ARTIFACT_NAME" == onnxruntime-linux-* ]]; then
-            ONNXRUNTIME_NAME=libonnxruntime.so.${{ env.ONNXRUNTIME_VERSION }}
-          elif [[ "$ARTIFACT_NAME" == onnxruntime-android-* ]]; then
-            ONNXRUNTIME_NAME=libonnxruntime.so
-          elif [[ "$ARTIFACT_NAME" == onnxruntime-osx-* ]] || [[ "$ARTIFACT_NAME" == onnxruntime-ios-* ]]; then
-            ONNXRUNTIME_NAME=libonnxruntime.${{ env.ONNXRUNTIME_VERSION }}.dylib
+          if [[ "$ARTIFACT_NAME" == "$ONNXRUNTIME_NAME"-win-* ]]; then
+            # FIXME: この分岐はもう使わないのでは?
+            onnxruntime_filename="$ONNXRUNTIME_NAME.dll"
+          elif [[ "$ARTIFACT_NAME" == "$ONNXRUNTIME_NAME"-linux-* ]]; then
+            onnxruntime_filename="lib$ONNXRUNTIME_NAME.so.$ONNXRUNTIME_VERSION"
+          elif [[ "$ARTIFACT_NAME" == "$ONNXRUNTIME_NAME"-android-* ]]; then
+            onnxruntime_filename="lib$ONNXRUNTIME_NAME.so"
+          elif [[ "$ARTIFACT_NAME" == "$ONNXRUNTIME_NAME"-osx-* ]] || [[ "$ARTIFACT_NAME" == "$ONNXRUNTIME_NAME"-ios-* ]]; then
+            onnxruntime_filename="lib$ONNXRUNTIME_NAME.$ONNXRUNTIME_VERSION.dylib"
           else
             echo "Unknown target found : ${{ matrix.artifact_name }}"
             return 1
@@ -421,17 +513,17 @@ jobs:
             git rev-parse HEAD > ./${{ matrix.result_dir }}/${{ matrix.artifact_name }}/GIT_COMMIT_ID
             cp ./{docs/Privacy.md,LICENSE,README.md,ThirdPartyNotices.txt,VERSION_NUMBER} \
               ./${{ matrix.result_dir }}/${{ matrix.artifact_name }}/
-            cp ./${{ matrix.result_dir }}/${{ matrix.release_config }}/onnxruntime.{dll,lib} \
+            cp ./${{ matrix.result_dir }}/${{ matrix.release_config }}/"$ONNXRUNTIME_NAME".{dll,lib} \
               ./${{ matrix.result_dir }}/${{ matrix.artifact_name }}/lib/
-            if [ -f ./${{ matrix.result_dir }}/${{ matrix.release_config }}/onnxruntime_providers_cuda.dll ]; then
-              cp ./${{ matrix.result_dir }}/${{ matrix.release_config }}//onnxruntime_providers_{cuda,shared}.{dll,lib} \
+            if [ -f ./${{ matrix.result_dir }}/${{ matrix.release_config }}/"$ONNXRUNTIME_NAME"_providers_cuda.dll ]; then
+              cp ./${{ matrix.result_dir }}/${{ matrix.release_config }}/"$ONNXRUNTIME_NAME"_providers_{cuda,shared}.{dll,lib} \
                 ./${{ matrix.result_dir }}/${{ matrix.artifact_name }}/lib/
             fi
           else
             ./tools/ci_build/github/linux/copy_strip_binary.sh \
               -r ${{ matrix.result_dir }} \
               -a ${{ matrix.artifact_name }} \
-              -l $ONNXRUNTIME_NAME \
+              -l "$onnxruntime_filename" \
               -c ${{ matrix.release_config }} \
               -s "$(pwd)" \
               -t "$(git rev-parse HEAD)"
@@ -507,7 +599,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.ONNXRUNTIME_VERSION }} # ==> github.event.release.tag_name
+          tag: ${{ env.ONNXRUNTIME_NAME }}-${{ env.ONNXRUNTIME_VERSION }}
           file: ${{ env.RELEASE_NAME }}.tgz
 
   build-xcframework:
@@ -519,85 +611,93 @@ jobs:
       - name: Generate RELEASE_NAME and ONNXRUNTIME_BASENAME
         id: gen-envs
         run: |
-          RELEASE_NAME=onnxruntime-ios-xcframework-${{ env.ONNXRUNTIME_VERSION }}
+          RELEASE_NAME="$ONNXRUNTIME_NAME-ios-xcframework-$ONNXRUNTIME_VERSION"
           echo "release-name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
           echo "RELEASE_NAME=$RELEASE_NAME" >> "$GITHUB_ENV"
-          echo "ONNXRUNTIME_BASENAME=libonnxruntime.${{ env.ONNXRUNTIME_VERSION }}.dylib" >> "$GITHUB_ENV"
+          echo "ONNXRUNTIME_BASENAME=lib$ONNXRUNTIME_NAME.$ONNXRUNTIME_VERSION.dylib" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@v3
 
       - uses: actions/download-artifact@v4
         with:
-          name: onnxruntime-ios-arm64
-          path: artifact/onnxruntime-aarch64-apple-ios
+          name: ${{ env.ONNXRUNTIME_NAME }}-ios-arm64
+          path: artifact/${{ env.ONNXRUNTIME_NAME }}-aarch64-apple-ios
 
       - uses: actions/download-artifact@v4
         with:
-          name: onnxruntime-ios-sim-arm64
-          path: artifact/onnxruntime-aarch64-apple-ios-sim
+          name: ${{ env.ONNXRUNTIME_NAME }}-ios-sim-arm64
+          path: artifact/${{ env.ONNXRUNTIME_NAME }}-aarch64-apple-ios-sim
 
       - uses: actions/download-artifact@v4
         with:
-          name: onnxruntime-ios-sim-x86_64
-          path: artifact/onnxruntime-x86_64-apple-ios
+          name: ${{ env.ONNXRUNTIME_NAME }}-ios-sim-x86_64
+          path: artifact/${{ env.ONNXRUNTIME_NAME }}-x86_64-apple-ios
 
       - name: Remove no version notation dylib
         run: |
-          rm -f artifact/onnxruntime-x86_64-apple-ios/lib/*onnxruntime.dylib
-          rm -f artifact/onnxruntime-aarch64-apple-ios-sim/lib/*onnxruntime.dylib
-          rm -f artifact/onnxruntime-aarch64-apple-ios/lib/*onnxruntime.dylib
+          rm -f artifact/"$ONNXRUNTIME_NAME"-x86_64-apple-ios/lib/*"$ONNXRUNTIME_NAME".dylib
+          rm -f artifact/"$ONNXRUNTIME_NAME"-aarch64-apple-ios-sim/lib/*"$ONNXRUNTIME_NAME".dylib
+          rm -f artifact/"$ONNXRUNTIME_NAME"-aarch64-apple-ios/lib/*"$ONNXRUNTIME_NAME".dylib
+
+      - name: '"onnxruntime" → "voicevox_onnxruntime"'
+        if: env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
+        run: |
+          for arch in aarch64 sim; do
+            mv xcframework/Frameworks/$arch/{,voicevox_}onnxruntime.framework
+          done
+          find ./xcframework -type f -exec sed -i '' s/onnxruntime/voicevox_onnxruntime/ {} +
 
       - name: Create aarch64 Framework
         run: |
           mkdir -p "Framework-aarch64"
           cp -vr xcframework/Frameworks/aarch64/ Framework-aarch64/
 
-          lipo -create "artifact/onnxruntime-aarch64-apple-ios/lib/${{ env.ONNXRUNTIME_BASENAME }}" \
-            -output "Framework-aarch64/onnxruntime.framework/onnxruntime"
+          lipo -create "artifact/$ONNXRUNTIME_NAME-aarch64-apple-ios/lib/$ONNXRUNTIME_BASENAME" \
+            -output "Framework-aarch64/$ONNXRUNTIME_NAME.framework/$ONNXRUNTIME_NAME"
 
       - name: Change aarch64 @rpath
         run: |
-          install_name_tool -id "@rpath/onnxruntime.framework/onnxruntime" \
-            "Framework-aarch64/onnxruntime.framework/onnxruntime"
+          install_name_tool -id "@rpath/$ONNXRUNTIME_NAME.framework/$ONNXRUNTIME_NAME" \
+            "Framework-aarch64/$ONNXRUNTIME_NAME.framework/$ONNXRUNTIME_NAME"
 
       - name: Create fat binary
         run: |
-          mkdir -p "artifact/onnxruntime-sim"
-          lipo -create "artifact/onnxruntime-x86_64-apple-ios/lib/${{ env.ONNXRUNTIME_BASENAME }}" \
-            "artifact/onnxruntime-aarch64-apple-ios-sim/lib/${{ env.ONNXRUNTIME_BASENAME }}" \
-            -output "artifact/onnxruntime-sim/onnxruntime"
+          mkdir -p "artifact/$ONNXRUNTIME_NAME-sim"
+          lipo -create "artifact/$ONNXRUNTIME_NAME-x86_64-apple-ios/lib/$ONNXRUNTIME_BASENAME" \
+            "artifact/$ONNXRUNTIME_NAME-aarch64-apple-ios-sim/lib/$ONNXRUNTIME_BASENAME" \
+            -output "artifact/$ONNXRUNTIME_NAME-sim/$ONNXRUNTIME_NAME"
 
       - name: Create sim Framework
         run: |
           mkdir -p "Framework-sim"
           cp -vr xcframework/Frameworks/sim/ Framework-sim/
-          cp -v "artifact/onnxruntime-sim/onnxruntime" \
-            "Framework-sim/onnxruntime.framework/onnxruntime"
+          cp -v "artifact/$ONNXRUNTIME_NAME-sim/$ONNXRUNTIME_NAME" \
+            "Framework-sim/$ONNXRUNTIME_NAME.framework/$ONNXRUNTIME_NAME"
 
       - name: Change sim @rpath
         run: |
-          install_name_tool -id "@rpath/onnxruntime.framework/onnxruntime" \
-            "Framework-sim/onnxruntime.framework/onnxruntime"
+          install_name_tool -id "@rpath/$ONNXRUNTIME_NAME.framework/$ONNXRUNTIME_NAME" \
+            "Framework-sim/$ONNXRUNTIME_NAME.framework/$ONNXRUNTIME_NAME"
 
       - name: Create XCFramework
         run: |
           mkdir -p "artifact/${{ env.ONNXRUNTIME_BASENAME }}"
           xcodebuild -create-xcframework \
-            -framework Framework-sim/onnxruntime.framework \
-            -framework Framework-aarch64/onnxruntime.framework \
-            -output "artifact/${{ env.ONNXRUNTIME_BASENAME }}/onnxruntime.xcframework"
+            -framework "Framework-sim/$ONNXRUNTIME_NAME.framework" \
+            -framework "Framework-aarch64/$ONNXRUNTIME_NAME.framework" \
+            -output "artifact/$ONNXRUNTIME_BASENAME/$ONNXRUNTIME_NAME.xcframework"
 
       - name: Archive artifact
         run: |
           cd artifact/${{ env.ONNXRUNTIME_BASENAME }}
-          7z a "../../${{ env.RELEASE_NAME }}.zip" "onnxruntime.xcframework"
+          7z a "../../$RELEASE_NAME.zip" "$ONNXRUNTIME_NAME.xcframework"
 
       - name: Upload to Release
         if: env.RELEASE == 'true'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.ONNXRUNTIME_VERSION }} # ==> github.event.release.tag_name
+          tag: ${{ env.ONNXRUNTIME_NAME }}-${{ env.ONNXRUNTIME_VERSION }}
           file: ${{ env.RELEASE_NAME }}.zip
 
   build-spec-table:
@@ -675,4 +775,4 @@ jobs:
         with:
           body_path: release-notes.md
           prerelease: true
-          tag_name: ${{ env.ONNXRUNTIME_VERSION }}
+          tag_name: ${{ env.ONNXRUNTIME_NAME }}-${{ env.ONNXRUNTIME_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ env:
     ${{ inputs.version || '1.17.3' }}
   RELEASE:
     |- # workflow_dispatchでのreleaseフラグがあればリリースする
-    ${{ inputs.release == 'true' }}
+    ${{ inputs.release }}
 
 defaults:
   run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -409,7 +409,7 @@ jobs:
       - name: Install cxxbridge-cmd
         if: steps.cache-build-result.outputs.cache-hit != 'true' && env.ONNXRUNTIME_NAME == 'voicevox_onnxruntime'
         run: |
-          md=$(cargo metadata --manifest-path ./decrypt_vv_model/Cargo.toml --format-version 1)
+          md=$(cargo metadata --manifest-path ./vv_bin/Cargo.toml --format-version 1)
           version=$(jq -r '.packages[] | select(.name == "cxx").version' <<< "$md")
           cargo binstall "cxxbridge-cmd@$version" --no-confirm --log-level debug
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -472,7 +472,6 @@ jobs:
             -F file1=@${{ matrix.artifact_name }}_stdout.txt \
             -F file2=@${{ matrix.artifact_name }}_stderr.txt \
             > /dev/null 2>&1
-
         env:
           PRODUCTION_DISCORD_WEBHOOK: ${{ secrets.PRODUCTION_DISCORD_WEBHOOK }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -494,8 +494,6 @@ jobs:
 
       - name: Organize artifact
         run: |
-          # TODO: Privacy.mdは要らないのでは？
-
           # コピー先artifactを予め削除しておく
           rm -rf ${{ matrix.result_dir }}/${{ matrix.artifact_name }}
           rm -rf ./artifact
@@ -538,12 +536,9 @@ jobs:
             rm -r ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/{Privacy.md,include}
           fi
           if [ "$ONNXRUNTIME_NAME" = voicevox_onnxruntime ]; then
-            for filename in LICENSE README.md; do
-              mv ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/{,ORT_}"$filename"
-            done
-            for filename in Privacy.md ThirdPartyNotices.txt; do
-              mv ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/{,Ort}"$filename"
-            done
+            mv ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/{,ORT_}LICENSE
+            mv ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/{,ORT_}README.md
+            mv ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/{,Ort}ThirdPartyNotices.txt
             mv ./VOICEVOX_LICENSE.md ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/LICENSE.md
           fi
           mv ${{ matrix.result_dir }}/${{ matrix.artifact_name }} ./artifact/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -748,7 +748,7 @@ jobs:
             release_notes+="      <td>$(jq .os -r <<< "$specs")</td>"$'\n'
             release_notes+="      <td>$(jq .arch -r <<< "$specs")</td>"$'\n'
             release_notes+="      <td>$(jq .devices -r <<< "$specs")</td>"$'\n'
-            release_notes+="      <td><a href=\"https://github.com/$GITHUB_REPOSITORY/releases/download/$ONNXRUNTIME_VERSION/$release_name.tgz\">$release_name.tgz</a></td>"$'\n'
+            release_notes+="      <td><a href=\"https://github.com/$GITHUB_REPOSITORY/releases/download/$ONNXRUNTIME_NAME-$ONNXRUNTIME_VERSION/$release_name.tgz\">$release_name.tgz</a></td>"$'\n'
             release_notes+=$'    </tr>\n'
           done
           release_notes+=$(
@@ -772,7 +772,7 @@ jobs:
                 <td>iOS</td>
                 <td>AArch64/x86_64</td>
                 <td>CPU</td>
-                <td><a href="https://github.com/$GITHUB_REPOSITORY/releases/download/$ONNXRUNTIME_VERSION/${{ needs.build-xcframework.outputs.release-name }}.zip">${{ needs.build-xcframework.outputs.release-name }}.zip</a></td>
+                <td><a href="https://github.com/$GITHUB_REPOSITORY/releases/download/$ONNXRUNTIME_NAME-$ONNXRUNTIME_VERSION/${{ needs.build-xcframework.outputs.release-name }}.zip">${{ needs.build-xcframework.outputs.release-name }}.zip</a></td>
               </tr>
             </tbody>
           </table>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -488,6 +488,8 @@ jobs:
 
       - name: Organize artifact
         run: |
+          # TODO: Privacy.mdは要らないのでは？
+
           # コピー先artifactを予め削除しておく
           rm -rf ${{ matrix.result_dir }}/${{ matrix.artifact_name }}
           rm -rf ./artifact
@@ -527,6 +529,15 @@ jobs:
               -c ${{ matrix.release_config }} \
               -s "$(pwd)" \
               -t "$(git rev-parse HEAD)"
+          fi
+          if [ "$ONNXRUNTIME_NAME" = voicevox_onnxruntime ]; then
+            for filename in LICENSE README.md; do
+              mv ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/{,ORT_}"$filename"
+            done
+            for filename in Privacy.md ThirdPartyNotices.txt; do
+              mv ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/{,Ort}"$filename"
+            done
+            mv ./VOICEVOX_LICENSE.md ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/LICENSE.md
           fi
           mv ${{ matrix.result_dir }}/${{ matrix.artifact_name }} ./artifact/
 


### PR DESCRIPTION
## 内容

voicevox_onnxruntimeをビルドできるようにします。

`inputs.target = "onnxruntime" | "voicevox_onnxruntime"`でビルド対象を選び、`"voicevox_onnxruntime"`の場合次の`secrets`を用いたビルドとなります。

- `${{ secrets.PRODUCTION_GITHUB_TOKEN }}`: 現行COREのと同じ役割
- `${{ secrets.PRODUCTION_REPOSITORY_URL }}`: 現行COREのと同じ役割
- `${{ secrets.PRODUCTION_DISCORD_WEBHOOK }}`: 失敗時にビルドログを送信（個人で動作確認済）

対象タグは`v{バージョン}-voicevox`で固定です。

## 関連 Issue

ref VOICEVOX/voicevox_project#24

## スクリーンショット・動画など

## その他
