### PR TITLE
remove: 不要なファイルをリリースに入れないようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -420,12 +420,12 @@ jobs:
             echo "Unknown target found : ${{ matrix.artifact_name }}"
             return 1
           fi
+          # PDBファイル, Privacy.md, include/は不要なので省く
           if [ ${{ runner.os }} = Windows ]; then
             # https://github.com/microsoft/onnxruntime/blob/v1.16.3/tools/ci_build/github/azure-pipelines/templates/c-api-artifacts-package-and-publish-steps-windows.yml#L34-L72
-            # ただし、ortクレートには.pdbとinclude/は不要なので入れない。
             mkdir -p ./${{ matrix.result_dir }}/${{ matrix.artifact_name }}/lib
             git rev-parse HEAD > ./${{ matrix.result_dir }}/${{ matrix.artifact_name }}/GIT_COMMIT_ID
-            cp ./{docs/Privacy.md,LICENSE,README.md,ThirdPartyNotices.txt,VERSION_NUMBER} \
+            cp ./{LICENSE,README.md,ThirdPartyNotices.txt,VERSION_NUMBER} \
               ./${{ matrix.result_dir }}/${{ matrix.artifact_name }}/
             cp ./${{ matrix.result_dir }}/${{ matrix.release_config }}/onnxruntime.{dll,lib} \
               ./${{ matrix.result_dir }}/${{ matrix.artifact_name }}/lib/
@@ -441,6 +441,7 @@ jobs:
               -c ${{ matrix.release_config }} \
               -s "$(pwd)" \
               -t "$(git rev-parse HEAD)"
+            rm -r ${{ matrix.result_dir }}/${{ matrix.artifact_name }}/{Privacy.md,include}
           fi
           mv ${{ matrix.result_dir }}/${{ matrix.artifact_name }} ./artifact/
 


### PR DESCRIPTION
## 内容

以下のファイルをリリースに含めないようにします。

- [Privacy.md](https://github.com/microsoft/onnxruntime/blob/v1.19.0/docs/Privacy.md) (我々のは"private build"であるため)
- include/

## 関連 Issue

## スクリーンショット・動画など

## その他

ちなみにpykeio/ortでのONNX Runtimeのダウンロード物はこんな感じになっています。内部利用専用であるためreadmeもありません。

```console
❯ tar --list -f ./ortrs-msort_dylib_cu12-v1.19.0-x86_64-pc-windows-msvc.tgz
onnxruntime/lib/onnxruntime.dll
onnxruntime/lib/onnxruntime.lib
onnxruntime/lib/onnxruntime_providers_cuda.dll
onnxruntime/lib/onnxruntime_providers_shared.dll
onnxruntime/lib/onnxruntime_providers_shared.lib
onnxruntime/lib/onnxruntime_providers_tensorrt.dll
```
