### PR TITLE
feat!: 署名ではなく`voicevox_onnxruntime`に`production`を使う

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,7 +244,7 @@ jobs:
       ARCH_SUFFIX: "${{ (matrix.linux_cross_arch != '' && '-') || '' }}${{ (matrix.linux_cross_arch != '' && matrix.linux_cross_arch) || '' }}"
 
     runs-on: ${{ matrix.os }}
-    environment: ${{ inputs.code_signing && 'production' || '' }} # コード署名用のenvironment
+    environment: ${{ inputs.target == 'voicevox_onnxruntime' && 'production' || '' }}
 
     steps:
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## 内容

この辺の区分けがよくわかっていませんが、今`voicevox_onnxruntime`のビルド自体に`production`を使っているのでこうしようかと。

## 関連 Issue

## スクリーンショット・動画など

## その他
