### PR TITLE
fix: iOS以外`CMAKE_SYSTEM_PROCESSOR`を指定

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
               --compile_no_warning_as_error
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Windows
-              CMAKE_SYSTEM_PROCESSOR=x86_64
+              CMAKE_SYSTEM_PROCESSOR=x86_64 # required for `cpuinfo`
               Rust_CARGO_TARGET=x86_64-pc-windows-msvc
             result_dir: build/Release
             release_config: Release
@@ -62,7 +62,7 @@ jobs:
               --use_dml
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Windows
-              CMAKE_SYSTEM_PROCESSOR=x86_64
+              CMAKE_SYSTEM_PROCESSOR=x86_64 # required for `cpuinfo`
               Rust_CARGO_TARGET=x86_64-pc-windows-msvc
             result_dir: build/Release
             release_config: Release
@@ -78,7 +78,7 @@ jobs:
               --cuda_version 12.4 # WindowsではCUDAのディレクトリを見つけ出すのに必要（1.16.3時点）
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Windows
-              CMAKE_SYSTEM_PROCESSOR=x86_64
+              CMAKE_SYSTEM_PROCESSOR=x86_64 # required for `cpuinfo`
               Rust_CARGO_TARGET=x86_64-pc-windows-msvc
             result_dir: build/Release
             release_config: Release
@@ -89,7 +89,7 @@ jobs:
               --x86
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Windows
-              CMAKE_SYSTEM_PROCESSOR=x86
+              CMAKE_SYSTEM_PROCESSOR=x86 # required for `cpuinfo`
               Rust_CARGO_TARGET=i686-pc-windows-msvc
             result_dir: build/Release
             release_config: Release
@@ -99,7 +99,7 @@ jobs:
               --compile_no_warning_as_error
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Linux
-              CMAKE_SYSTEM_PROCESSOR=x86_64
+              CMAKE_SYSTEM_PROCESSOR=x86_64 # required for `cpuinfo`
               Rust_CARGO_TARGET=x86_64-unknown-linux-gnu
             result_dir: build
             release_config: Release
@@ -113,7 +113,7 @@ jobs:
               --use_cuda
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Linux
-              CMAKE_SYSTEM_PROCESSOR=x86_64
+              CMAKE_SYSTEM_PROCESSOR=x86_64 # required for `cpuinfo`
               Rust_CARGO_TARGET=x86_64-unknown-linux-gnu
             result_dir: build
             release_config: Release
@@ -128,7 +128,7 @@ jobs:
               --arm
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Linux
-              CMAKE_SYSTEM_PROCESSOR=armv7l
+              CMAKE_SYSTEM_PROCESSOR=armv7l # required for `cpuinfo`
               Rust_CARGO_TARGET=armv7-unknown-linux-gnueabihf
             result_dir: build
             release_config: Release
@@ -143,7 +143,7 @@ jobs:
               --arm64
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Linux
-              CMAKE_SYSTEM_PROCESSOR=aarch64
+              CMAKE_SYSTEM_PROCESSOR=aarch64 # required for `cpuinfo`
               Rust_CARGO_TARGET=aarch64-unknown-linux-gnu
             result_dir: build
             release_config: Release
@@ -154,6 +154,7 @@ jobs:
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Darwin
               CMAKE_OSX_ARCHITECTURES=arm64
+              CMAKE_SYSTEM_PROCESSOR=arm64 # required for `cpuinfo`
               Rust_CARGO_TARGET=aarch64-apple-darwin
             result_dir: build
             release_config: Release
@@ -164,6 +165,7 @@ jobs:
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Darwin
               CMAKE_OSX_ARCHITECTURES=x86_64
+              CMAKE_SYSTEM_PROCESSOR=x86_64 # required for `cpuinfo`
               Rust_CARGO_TARGET=x86_64-apple-darwin
             result_dir: build
             release_config: Release
@@ -175,7 +177,7 @@ jobs:
               --android_abi x86_64
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Android
-              CMAKE_SYSTEM_PROCESSOR=x86_64
+              CMAKE_SYSTEM_PROCESSOR=x86_64 # required for `cpuinfo`
               Rust_CARGO_TARGET=x86_64-linux-android
             result_dir: build
             release_config: Release
@@ -187,7 +189,7 @@ jobs:
               --android_abi arm64-v8a
               --cmake_extra_defines
               CMAKE_SYSTEM_NAME=Android
-              CMAKE_SYSTEM_PROCESSOR=aarch64
+              CMAKE_SYSTEM_PROCESSOR=aarch64 # required for `cpuinfo`
               Rust_CARGO_TARGET=aarch64-linux-android
             result_dir: build
             release_config: Release


### PR DESCRIPTION
## 内容

追記: <https://github.com/VOICEVOX/onnxruntime-builder/pull/61#issuecomment-2564582707>

## 関連 Issue

Refs: https://github.com/VOICEVOX/voicevox_core/issues/888#issuecomment-2564133514

## スクリーンショット・動画など

## その他
