### PR TITLE
fix: Releaseの作成時点で`prerelease: true`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -616,6 +616,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.TARGET_LIBRARY }}-${{ env.ONNXRUNTIME_VERSION }}
           file: ${{ env.RELEASE_NAME }}.tgz
+          prerelease: true
 
   build-xcframework:
     needs: build-onnxruntime
@@ -714,6 +715,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.TARGET_LIBRARY }}-${{ env.ONNXRUNTIME_VERSION }}
           file: ${{ env.RELEASE_NAME }}.zip
+          prerelease: true
 
   build-spec-table:
     needs: [build-onnxruntime, build-xcframework]


### PR DESCRIPTION
## 内容

現在、ワークフローの最後のリリースノートの書き込みのときにリリースがprereleaseになるようになっている。

<https://github.com/VOICEVOX/onnxruntime-builder/blob/00edd0759d44cc3fe3a2460e0b898c09da1ef5bf/.github/workflows/build.yml#L787-L792>

しかし、最初にリリースが作られる段階ではprereleaseではないようなので、最初からprereleaseになるようにする。

## 関連 Issue

## スクリーンショット・動画など

## その他
