### PR TITLE
fix: fix up #73: `strip(1)`が使えないケースは諦める

### DIFF
--- a/1_17_3_strip.patch
+++ b/1_17_3_strip.patch
@@ -6,9 +6,15 @@
  then
 -    dsymutil $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME -o $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME.dSYM
      strip -S $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME
-@@ -46,4 +44,5 @@ elif [[ $LIB_NAME == *.so.* ]]
+@@ -46,4 +44,11 @@ elif [[ $LIB_NAME == *.so.* ]]
  fi
-+strip -s $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME
++if [[ $LIB_NAME == *.dylib ]]
++then
++    strip -x $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME
++elif [[ $LIB_NAME == *.so.* ]]
++then
++    strip -s $BINARY_DIR/$ARTIFACT_NAME/lib/$LIB_NAME || true # クロスコンパイルでは不可であるため
++fi
  cp $SOURCE_DIR/include/onnxruntime/core/session/onnxruntime_*.h $BINARY_DIR/$ARTIFACT_NAME/include
  cp $SOURCE_DIR/include/onnxruntime/core/framework/provider_options.h  $BINARY_DIR/$ARTIFACT_NAME/include
  cp $SOURCE_DIR/include/onnxruntime/core/providers/cpu/cpu_provider_factory.h  $BINARY_DIR/$ARTIFACT_NAME/include


### PR DESCRIPTION
## 内容

macOS: `-s, --strip-all`は存在しないので、代わりに`-Sx` (`--strip-debug --discard-all`)で`strip`する。
ARM版Linux: 現段階では諦める。

## 関連 Issue

## スクリーンショット・動画など

## その他

#73 のビルドを確認しないままマージしたことによって壊れてしまったので、それに対する修正です。
