### PR TITLE
feat!: SemVerのbuild metadataとしてコミット日付とハッシュを入れる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "バージョン情報（A.BB.C / A.BB.C-preview.D）"
+        description: "バージョン情報（A.BB.C）"
         required: true
       target:
         description: "ビルド対象"
@@ -90,7 +90,7 @@ jobs:
             result_dir: build/Release
             release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-linux-x64
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             build_opts: |-
               --compile_no_warning_as_error
               --cmake_extra_defines
@@ -99,7 +99,7 @@ jobs:
             result_dir: build
             release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-linux-x64-cuda
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             cuda_version: 12.4.1
             cuda_sub_packages: "[]" # デフォルト
             cudnn_url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.9.7.29_cuda12-archive.tar.xz
@@ -112,7 +112,7 @@ jobs:
             result_dir: build
             release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-linux-armhf
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             cc_version: "10"
             cxx_version: "10"
             linux_cross_arch: arm-linux-gnueabihf
@@ -126,7 +126,7 @@ jobs:
             result_dir: build
             release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-linux-arm64
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             cc_version: "10"
             cxx_version: "10"
             linux_cross_arch: aarch64-linux-gnu
@@ -160,7 +160,7 @@ jobs:
             result_dir: build
             release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-android-x64
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             build_opts: |-
               --compile_no_warning_as_error
               --android
@@ -171,7 +171,7 @@ jobs:
             result_dir: build
             release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-android-arm64
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             build_opts: |-
               --compile_no_warning_as_error
               --android
@@ -230,6 +230,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     environment: ${{ inputs.target == 'voicevox_onnxruntime' && 'production' || '' }}
 
+    outputs:
+      release-version: ${{ steps.release-version.outputs.release-version }}
+
     steps:
       - uses: actions/setup-python@v5
         with:
@@ -238,12 +241,24 @@ jobs:
       - name: Version check (semver)
         run: |
           VERSION=$ONNXRUNTIME_VERSION
-          if [[ $VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]]; then
+          if [[ $VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
             echo "Version: $VERSION"
           else
-            echo "$VERSION is not a valid semver."
+            # shellcheck disable=SC2016
+            echo '`version` must be a semver without <pre-release> and without <build>.'
             exit 1
           fi
+
+      - name: Checkout builder
+        uses: actions/checkout@v4
+        with:
+          path: builder
+
+      - name: Determine the release version
+        id: release-version
+        run: |
+          commit_date_and_abbr_hash=$(GIT_DIR=./builder/.git git log -1 --format=%cd-%h --date format:%Y%m%d%H%M%S)
+          echo "release-version=$ONNXRUNTIME_VERSION+$commit_date_and_abbr_hash" >> "$GITHUB_OUTPUT"
 
       - name: Dump matrix context
         env:
@@ -256,7 +271,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build/
-          key: ${{ matrix.artifact_name }}-v${{ env.ONNXRUNTIME_VERSION }}-cache-${{ hashFiles('matrix.json') }}
+          key: ${{ matrix.artifact_name }}-v${{ steps.release-version.outputs.release-version }}-cache-${{ hashFiles('matrix.json') }}
 
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@main
@@ -347,6 +362,10 @@ jobs:
           echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> "$GITHUB_ENV"
 
       # workaround for https://github.com/actions/checkout/issues/1201
+      - name: Stash builder
+        if: steps.cache-build-result.outputs.cache-hit != 'true'
+        run: mv ./builder "$RUNNER_TEMP/"
+
       - name: Stash build directory
         if: steps.cache-build-result.outputs.cache-hit == 'true'
         run: mv ./build "$RUNNER_TEMP/"
@@ -358,6 +377,10 @@ jobs:
           repository: microsoft/onnxruntime
           submodules: true
           ref: v${{ env.ONNXRUNTIME_VERSION }}
+
+      - name: Restore the stashed builder
+        if: steps.cache-build-result.outputs.cache-hit != 'true'
+        run: mv "$RUNNER_TEMP/builder" .
 
       - name: Restore the stashed build directory
         if: steps.cache-build-result.outputs.cache-hit == 'true'
@@ -384,12 +407,8 @@ jobs:
         env:
           PRODUCTION_REPOSITORY_URL: ${{ secrets.PRODUCTION_REPOSITORY_URL }}
 
-      - name: Checkout builder
-        uses: actions/checkout@v4
-        with:
-          path: builder
-
       - name: Apply patch
+        if: steps.cache-build-result.outputs.cache-hit != 'true'
         run: |
           git apply --ignore-whitespace --reject --whitespace=fix --verbose ./builder/1_17_3_*.patch
 
@@ -611,7 +630,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.TARGET_LIBRARY }}-${{ env.ONNXRUNTIME_VERSION }}
+          tag: ${{ env.TARGET_LIBRARY }}-${{ steps.release-version.outputs.release-version }}
           file: ${{ env.RELEASE_NAME }}.tgz
           prerelease: true
 
@@ -710,7 +729,7 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.TARGET_LIBRARY }}-${{ env.ONNXRUNTIME_VERSION }}
+          tag: ${{ env.TARGET_LIBRARY }}-${{ needs.build-onnxruntime.outputs.release-version }}
           file: ${{ env.RELEASE_NAME }}.zip
           prerelease: true
 
@@ -790,7 +809,7 @@ jobs:
             release_notes+="      <td>$(jq .os -r <<< "$specs")</td>"$'\n'
             release_notes+="      <td>$(jq .arch -r <<< "$specs")</td>"$'\n'
             release_notes+="      <td>$(jq .devices -r <<< "$specs")</td>"$'\n'
-            release_notes+="      <td><a href=\"https://github.com/$GITHUB_REPOSITORY/releases/download/$TARGET_LIBRARY-$ONNXRUNTIME_VERSION/$release_name.tgz\">$release_name.tgz</a></td>"$'\n'
+            release_notes+="      <td><a href=\"https://github.com/$GITHUB_REPOSITORY/releases/download/$TARGET_LIBRARY-${{ needs.build-onnxruntime.outputs.release-version }}/$release_name.tgz\">$release_name.tgz</a></td>"$'\n'
             release_notes+=$'    </tr>\n'
           done
           release_notes+=$(
@@ -814,7 +833,7 @@ jobs:
                 <td>iOS</td>
                 <td>AArch64/x86_64</td>
                 <td>CPU</td>
-                <td><a href="https://github.com/$GITHUB_REPOSITORY/releases/download/$TARGET_LIBRARY-$ONNXRUNTIME_VERSION/${{ needs.build-xcframework.outputs.release-name }}.zip">${{ needs.build-xcframework.outputs.release-name }}.zip</a></td>
+                <td><a href="https://github.com/$GITHUB_REPOSITORY/releases/download/$TARGET_LIBRARY-${{ needs.build-onnxruntime.outputs.release-version }}/${{ needs.build-xcframework.outputs.release-name }}.zip">${{ needs.build-xcframework.outputs.release-name }}.zip</a></td>
               </tr>
             </tbody>
           </table>
@@ -834,4 +853,4 @@ jobs:
         with:
           body_path: release-notes.md
           prerelease: true
-          tag_name: ${{ env.TARGET_LIBRARY }}-${{ env.ONNXRUNTIME_VERSION }}
+          tag_name: ${{ env.TARGET_LIBRARY }}-${{ needs.build-onnxruntime.outputs.release-version }}


### PR DESCRIPTION
## 内容

`voicevox_onnxruntime-1.17.3`のようにしていたリリース名を、`voicevox_onnxruntime-1.17.3+20250501182355-749b107`のようにする。

理由としては、あるONNX Runtimeのバージョン（e.g. "1.17.3"）に対して「正式なリリース」を複数回出したい場合が考えられるため。最近だと[CUDAのバージョンを引き下げたリリースを出したい](https://github.com/VOICEVOX/voicevox_engine/pull/1587#discussion_r2068701953)。

「previewバージョン」も不要になるはず。

## 関連 Issue

## スクリーンショット・動画など

## その他
