### PR TITLE
ci: macOS runner の macos-13 をアップデート

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
             result_dir: build
             release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-osx-arm64
-            os: macos-13
+            os: macos-14
             build_opts: |-
               --compile_no_warning_as_error
               --cmake_extra_defines
@@ -150,7 +150,7 @@ jobs:
             result_dir: build
             release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-osx-x86_64
-            os: macos-13
+            os: macos-14
             build_opts: |-
               --compile_no_warning_as_error
               --cmake_extra_defines
@@ -182,7 +182,7 @@ jobs:
             result_dir: build
             release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-ios-arm64
-            os: macos-13
+            os: macos-14
             build_opts: |-
               --compile_no_warning_as_error
               --skip_tests
@@ -195,7 +195,7 @@ jobs:
             result_dir: build/Release
             release_config: Release-iphoneos
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-ios-sim-arm64
-            os: macos-13
+            os: macos-14
             build_opts: |-
               --compile_no_warning_as_error
               --skip_tests
@@ -208,7 +208,7 @@ jobs:
             result_dir: build/Release
             release_config: Release-iphonesimulator
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-ios-sim-x86_64
-            os: macos-13
+            os: macos-14
             build_opts: |-
               --compile_no_warning_as_error
               --skip_tests
@@ -617,7 +617,7 @@ jobs:
 
   build-xcframework:
     needs: build-onnxruntime
-    runs-on: macos-13
+    runs-on: macos-14
     outputs:
       release-name: ${{ steps.gen-envs.outputs.release-name }}
     steps:


### PR DESCRIPTION
## 内容

macOS 13 runnerが2025年12月4日に廃止されるため、macOS runnerを `macos-13` から `macos-14` にアップデートします。

全てのビルドでターゲットアーキテクチャが明示的に指定されているため（`CMAKE_OSX_ARCHITECTURES`、`--osx_arch`等）、おそらくmacos-14（ARM）ホストから全てのmacOS/iOSターゲットをクロスコンパイル可能です。

## 関連 Issue

GitHub Actionsの公式アナウンスに対応:
https://github.com/actions/runner-images/issues/11083

## スクリーンショット・動画など

N/A

## その他

この変更により、ARM macOSホストから以下のターゲットを全てクロスコンパイルします：
- macOS x86_64
- macOS arm64
- iOS arm64
- iOS Simulator arm64
- iOS Simulator x86_64