### PR TITLE
build: キャッシュの量を減らすため不要なファイルを削除

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -506,6 +506,7 @@ jobs:
       - name: Remove known unnecessary files
         if: steps.cache-build-result.outputs.cache-hit != 'true' && env.TARGET_LIBRARY == 'onnxruntime'
         run: |
+          find ./build -maxdepth 1 -name Packages -print -exec rm -r {} +
           find ./build/Release -maxdepth 1 '(' -name _deps -o -name testdata ')' -print -exec rm -r {} +
           find ./build/Release -maxdepth 1 '(' -name '*.a' -o -name '*.lib' -not -name onnxruntime.lib ')' -print -delete
           find ./build/Release/CMakeFiles -mindepth 1 -maxdepth 1 -not -name Export -print -exec rm -r {} +


### PR DESCRIPTION
## 内容

WebGPU版ビルドが入った #90 以降キャッシュの合計が10GBを超過してしまい、キャッシュ機構があまり機能しなくなってしまった問題があったのでそれに対処する。

## その他

このPRを作った段階で、以下の状態までは削減できている。

```console
❯ gh cache -R qryxip/onnxruntime-builder list --json sizeInBytes -q 'add(map(.sizeInBytes)[])' \
    | numfmt --to=iec
4.1G
```

```console
❯ gh cache -R qryxip/onnxruntime-builder list -S size_in_bytes --json key,sizeInBytes \
    -q '.[] | select(.key | startswith("onnxruntime-")) | [(.key | split("-v1.23.2")[0]), .sizeInBytes] | @tsv' \
    | teip -f 2 -- numfmt --to=iec \
    | column -ts $'\t'
onnxruntime-win-x64-dml         1016M
onnxruntime-win-x64-webgpu      603M
onnxruntime-win-x64-cuda        560M
onnxruntime-win-x64             548M
onnxruntime-win-x86             511M
onnxruntime-ios-sim-x86_64      164M
onnxruntime-linux-x64-cuda      70M
onnxruntime-linux-x64-webgpu    69M
onnxruntime-linux-arm64-webgpu  64M
onnxruntime-linux-x64           52M
onnxruntime-android-x64         51M
onnxruntime-android-arm64       50M
onnxruntime-osx-x86_64-webgpu   49M
onnxruntime-linux-arm64         47M
onnxruntime-ios-sim-arm64       46M
onnxruntime-ios-arm64           46M
onnxruntime-linux-armhf         46M
onnxruntime-osx-arm64-webgpu    44M
onnxruntime-osx-x86_64          39M
onnxruntime-osx-arm64           35M
```
