### PR TITLE
feat: macOSでコード署名する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -610,11 +610,18 @@ jobs:
 
       - name: Code signing (Windows)
         if: runner.os == 'Windows' && inputs.code_signing
-        run: find ./artifact/lib -name '*.dll' -exec ./builder/codesign.bash {} ';'
+        run: find ./artifact/lib -name '*.dll' -exec ./builder/codesign_windows.bash {} ';'
         env:
           ESIGNERCKA_USERNAME: ${{ secrets.ESIGNERCKA_USERNAME }}
           ESIGNERCKA_PASSWORD: ${{ secrets.ESIGNERCKA_PASSWORD }}
           ESIGNERCKA_TOTP_SECRET: ${{ secrets.ESIGNERCKA_TOTP_SECRET }}
+
+      - name: Code signing (macOS)
+        if: runner.os == 'macOS' && inputs.code_signing
+        run: find ./artifact/lib -name '*.dylib' -exec ./builder/codesign_macos.bash {} ';'
+        env:
+          APPLE_P12_BASE64: ${{ secrets.APPLE_P12_BASE64 }}
+          APPLE_P12_PASSWORD: ${{ secrets.APPLE_P12_PASSWORD }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/codesign_macos.bash
+++ b/codesign_macos.bash
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# !!! コードサイニング証明書を取り扱うので取り扱い注意 !!!
+
+# macOS上で.p12証明書を使ってコード署名する
+
+set -eu
+
+if [ ! -v APPLE_P12_BASE64 ]; then # .p12証明書のbase64エンコードされた内容
+    echo "APPLE_P12_BASE64が未定義です"
+    exit 1
+fi
+if [ ! -v APPLE_P12_PASSWORD ]; then # .p12証明書のパスワード
+    echo "APPLE_P12_PASSWORDが未定義です"
+    exit 1
+fi
+
+if [ $# -ne 1 ]; then
+    echo "引数の数が一致しません"
+    exit 1
+fi
+target_file_glob="$1"
+
+# .p12証明書のデコード
+P12_PATH="$(mktemp -d)/codesign.p12"
+echo "$APPLE_P12_BASE64" | base64 --decode > "$P12_PATH"
+
+# 一時キーチェーンのセットアップ
+KEYCHAIN_PATH="$(mktemp -d)/codesign.keychain-db"
+KEYCHAIN_PASSWORD="$(uuidgen)"
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+# Apple中間証明書のインポート
+DEVELOPER_ID_G2_CA="$(mktemp)"
+curl -fsSL -o "$DEVELOPER_ID_G2_CA" "https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer"
+security import "$DEVELOPER_ID_G2_CA" -k "$KEYCHAIN_PATH"
+rm "$DEVELOPER_ID_G2_CA"
+
+# .p12証明書のインポート
+security import "$P12_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_P12_PASSWORD" -T /usr/bin/codesign -A
+security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+
+ORIGINAL_KEYCHAINS=()
+while IFS= read -r line; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line#\"}"
+    line="${line%\"}"
+    [ -n "$line" ] && ORIGINAL_KEYCHAINS+=("$line")
+done < <(security list-keychains -d user)
+security list-keychains -d user -s "$KEYCHAIN_PATH" "${ORIGINAL_KEYCHAINS[@]}"
+
+IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | awk 'match($0,/[0-9A-F]{40}/){print substr($0,RSTART,RLENGTH); exit}')
+if [ -z "$IDENTITY" ]; then
+    echo "署名用の有効なIdentityが見つかりません"
+    exit 1
+fi
+
+# 証明書を破棄
+cleanup() {
+    security delete-keychain "$KEYCHAIN_PATH"
+    rm -f "$P12_PATH"
+}
+trap cleanup EXIT
+
+# 指定ファイルに署名する
+function codesign_file() {
+    TARGET="$1"
+    codesign --force --sign "$IDENTITY" --timestamp "$TARGET"
+}
+
+# 指定ファイルがadhoc以外で署名されているか
+function is_signed() {
+    TARGET="$1"
+    codesign -dv "$TARGET" 2>&1 | grep -q "^Signature=adhoc" && return 1
+    codesign --verify "$TARGET" >/dev/null 2>&1 || return 1
+}
+
+# 署名されていなければ署名
+# shellcheck disable=SC2012,SC2086
+ls $target_file_glob | while read -r target_file; do
+    if is_signed "$target_file"; then
+        echo "署名済み: $target_file"
+    else
+        echo "署名開始: $target_file"
+        codesign_file "$target_file"
+    fi
+done

--- a/codesign_windows.bash
+++ b/codesign_windows.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # !!! コードサイニング証明書を取り扱うので取り扱い注意 !!!
 
-# eSignerCKAを使ってコード署名する
+# Windows上でeSignerCKAを使ってコード署名する
 
 set -eu
 
@@ -49,6 +49,12 @@ THUMBPRINT=$(
     '
 )
 
+# 証明書を破棄
+cleanup() {
+    powershell "& '$INSTALL_DIR\eSignerCKATool.exe' unload"
+}
+trap cleanup EXIT
+
 # 指定ファイルに署名する
 function codesign() {
     TARGET="$1"
@@ -74,6 +80,3 @@ ls $target_file_glob | while read -r target_file; do
         codesign "$target_file"
     fi
 done
-
-# 証明書を破棄
-powershell "& '$INSTALL_DIR\eSignerCKATool.exe' unload"


### PR DESCRIPTION
## 内容

Closes #99

macOSでライブラリ（`.dylib`）のコード署名を行えるようにします。

## 変更

- `codesign.bash` を `codesign_windows.bash` にリネーム
- `codesign_macos.bash` を新規追加（VOICEVOX/voicevox_core#1326 と同様）
- `build.yml` に macOS署名ステップを追加

## 参考

- VOICEVOX/voicevox_core#1325
- VOICEVOX/voicevox_core#1326

🤖 Generated with [Claude Code](https://claude.com/claude-code)