### PR TITLE
ci: リリース更新に contents: write を明示する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,6 +268,8 @@ jobs:
       ARCH_SUFFIX: "${{ (matrix.linux_cross_arch != '' && '-') || '' }}${{ (matrix.linux_cross_arch != '' && matrix.linux_cross_arch) || '' }}"
 
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     environment: ${{ inputs.target == 'voicevox_onnxruntime' && 'production' || '' }}
 
     steps:
@@ -694,6 +696,8 @@ jobs:
   build-xcframework:
     needs: build-onnxruntime
     runs-on: macos-14
+    permissions:
+      contents: write
     outputs:
       release-name: ${{ steps.gen-envs.outputs.release-name }}
     steps:
@@ -826,6 +830,8 @@ jobs:
   build-spec-table:
     needs: [build-onnxruntime, build-xcframework, get-terms]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: Download specifications
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## 内容

GITHUB_TOKEN のデフォルト権限を read-only にする準備として、write が必要な job に permissions を明示します。

- GitHub Release へアップロードまたは release notes 更新を行う job に `contents: write` を明示します。
- `PRODUCTION_GITHUB_TOKEN` 用途は対象外として触っていません。
- public resource の read 用 permissions は追加していません。

## 関連 Issue

ref VOICEVOX/voicevox_project#93
