### PR TITLE
ci: actionlint ダウンロード時に SHA256 チェックサムを検証する

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -20,5 +20,8 @@ jobs:
 
       - name: actionlint
         run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          curl -LO \
+              "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint_1.7.12_linux_amd64.tar.gz" | sha256sum --check
+          tar -xzf actionlint_1.7.12_linux_amd64.tar.gz actionlint
           ./actionlint -color


### PR DESCRIPTION
## 内容

VOICEVOX/voicevox_project#94 の対応として、actionlint バイナリの取得を `download-actionlint.bash` 経由から公式リリースアセットの直接取得に変更し、SHA256 チェックサムを検証するようにしました。

参考: VOICEVOX/voicevox#2999, VOICEVOX/voicevox_engine#1855

## 関連 Issue

ref VOICEVOX/voicevox_project#94

## スクリーンショット・動画など

## その他