### PR TITLE
fix: 署名スクリプトの`[ ! -v VAR ]`を`[ -z "${VAR:-} ]`に

### DIFF
--- a/codesign_macos.bash
+++ b/codesign_macos.bash
@@ -5,11 +5,11 @@
 
 set -eu
 
-if [ ! -v APPLE_P12_BASE64 ]; then # .p12証明書のbase64エンコードされた内容
+if [ -z "${APPLE_P12_BASE64:-}" ]; then # .p12証明書のbase64エンコードされた内容
     echo "APPLE_P12_BASE64が未定義です"
     exit 1
 fi
-if [ ! -v APPLE_P12_PASSWORD ]; then # .p12証明書のパスワード
+if [ -z "${APPLE_P12_PASSWORD:-}" ]; then # .p12証明書のパスワード
     echo "APPLE_P12_PASSWORDが未定義です"
     exit 1
 fi

--- a/codesign_macos.bash
+++ b/codesign_macos.bash
@@ -6,11 +6,11 @@
 set -eu
 
 if [ -z "${APPLE_P12_BASE64:-}" ]; then # .p12証明書のbase64エンコードされた内容
-    echo "APPLE_P12_BASE64が未定義です"
+    echo "APPLE_P12_BASE64が未定義もしくは空文字列です"
     exit 1
 fi
 if [ -z "${APPLE_P12_PASSWORD:-}" ]; then # .p12証明書のパスワード
-    echo "APPLE_P12_PASSWORDが未定義です"
+    echo "APPLE_P12_PASSWORDが未定義もしくは空文字列です"
     exit 1
 fi
 

--- a/codesign_windows.bash
+++ b/codesign_windows.bash
@@ -6,16 +6,16 @@
 
 set -eu
 
-if [ ! -v ESIGNERCKA_USERNAME ]; then # eSignerCKAのユーザー名
-    echo "ESIGNERCKA_USERNAMEが未定義です"
+if [ -z "${ESIGNERCKA_USERNAME:-}" ]; then # eSignerCKAのユーザー名
+    echo "ESIGNERCKA_USERNAMEが未定義もしくは空文字列です"
     exit 1
 fi
-if [ ! -v ESIGNERCKA_PASSWORD ]; then # eSignerCKAのパスワード
-    echo "ESIGNERCKA_PASSWORDが未定義です"
+if [ -z "${ESIGNERCKA_PASSWORD:-}" ]; then # eSignerCKAのパスワード
+    echo "ESIGNERCKA_PASSWORDが未定義もしくは空文字列です"
     exit 1
 fi
-if [ ! -v ESIGNERCKA_TOTP_SECRET ]; then # eSignerCKAのTOTP Secret
-    echo "ESIGNERCKA_TOTP_SECRETが未定義です"
+if [ -z "${ESIGNERCKA_TOTP_SECRET:-}" ]; then # eSignerCKAのTOTP Secret
+    echo "ESIGNERCKA_TOTP_SECRETが未定義もしくは空文字列です"
     exit 1
 fi
 


### PR DESCRIPTION
## 内容

\[追記\] 環境変数が定義されているが空という場合でも弾くようにする。というよりGHA上で起動する関係で、そのようなケースが主であるはず。

macOSのBash 3.2では`test(1)`の`-v`が使えないため、迂回 ~~する~~ というのも目的。

経緯: <https://github.com/VOICEVOX/onnxruntime-builder/issues/99#issuecomment-4772481400>
