### PR TITLE
build: タグ名が既にあるものと重複しても拒否しない

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,8 @@ jobs:
       - name: Nop
         run: ':'
 
+  # 他のリポジトリとは異なり、既存の同名のtag_nameがあることを許容する。
+  # 何故なら本リポジトリではリリースの「差し替え」を行うため（ゆえにimmutable releaseも使わない）。
   create-draft-release:
     needs: config
     runs-on: ubuntu-latest
@@ -63,9 +65,6 @@ jobs:
       # `RELEASE`がtrueなら、GitHub REST APIの`Release`オブジェクトの一部。falseならnull。
       release: ${{ steps.create-draft-release.outputs.release || 'null' }}
     steps:
-      # 他のリポジトリとは異なり、既存の同名のtag_nameがあることを許容する。
-      # 何故なら本リポジトリではリリースの「差し替え」を行うため（ゆえにimmutable releaseも使わない）。
-
       - name: Create a tagless draft release
         if: env.RELEASE == 'true'
         id: create-draft-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -992,8 +992,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      # 当該のtag_nameが既に存在していた場合、出来上がったdraft releaseをブラウザで開くと"Target"は"Tag"が指すコミットになってしまっているように見える。
-      # しかしそれはブラウザでの見た目のみであり、実際にはtarget_commitishはちゃんとtag_nameとは別個に設定されている。
       - name: Set the tag name
         if: env.RELEASE == 'true'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         run: ':'
 
   # 他のリポジトリとは異なり、既存の同名のtag_nameがあることを許容する。
-  # 何故なら本リポジトリではリリースの「差し替え」を行うため（ゆえにimmutable releaseも使わない）。
+  # 何故なら本リポジトリではリリースの差し替えを行うため。ゆえにimmutable releaseも使わない。
   create-draft-release:
     needs: config
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,23 +63,8 @@ jobs:
       # `RELEASE`がtrueなら、GitHub REST APIの`Release`オブジェクトの一部。falseならnull。
       release: ${{ steps.create-draft-release.outputs.release || 'null' }}
     steps:
-      - name: Confirm that the tag does not exist at the moment
-        if: env.RELEASE == 'true'
-        run: |
-          tag=${{ needs.config.outputs.tag }}
-          exists=$(
-            gh api \
-              "/repos/$GITHUB_REPOSITORY/git/matching-refs/tags/$tag" \
-              -H 'Accept: application/vnd.github+json' \
-              -H 'X-GitHub-Api-Version: 2022-11-28' \
-              -q '[.] | flatten | any(.ref == "refs/tags/'$tag'")'
-          )
-          if [ "$exists" = true ]; then
-            echo "::error title=create-draft-release::'refs/tags/$tag' already exists"
-            exit 1
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # 他のリポジトリとは異なり、既存の同名のtag_nameがあることを許容する。
+      # 何故なら本リポジトリではリリースの「差し替え」を行うため（ゆえにimmutable releaseも使わない）。
 
       - name: Create a tagless draft release
         if: env.RELEASE == 'true'
@@ -1008,8 +993,24 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Set the tag name
+      - name: Check whether the tag already exists
         if: env.RELEASE == 'true'
+        id: check-tag-existence
+        run: |
+          tag=${{ needs.config.outputs.tag }}
+          exists=$(
+            gh api \
+              "/repos/$GITHUB_REPOSITORY/git/matching-refs/tags/$tag" \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              -q '[.] | flatten | any(.ref == "refs/tags/'$tag'")'
+          )
+          echo "exists=$exists" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set the tag name
+        if: env.RELEASE == 'true' && steps.check-tag-existence.outputs.exists != 'true'
         run: |
           tag=${{ needs.config.outputs.tag }}
           release_id=${{ fromJson(needs.create-draft-release.outputs.release).id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -993,6 +993,8 @@ jobs:
     permissions:
       contents: write
     steps:
+      # 当該のtag_nameが既に存在していた場合、出来上がったdraft releaseをブラウザで開くと"Target"は"Tag"が指すコミットになってしまっているように見える。
+      # しかしそれはブラウザでの見た目のみであり、実際にはtarget_commitishはちゃんとtag_nameとは別個に設定されている。
       - name: Set the tag name
         if: env.RELEASE == 'true'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -993,24 +993,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Check whether the tag already exists
-        if: env.RELEASE == 'true'
-        id: check-tag-existence
-        run: |
-          tag=${{ needs.config.outputs.tag }}
-          exists=$(
-            gh api \
-              "/repos/$GITHUB_REPOSITORY/git/matching-refs/tags/$tag" \
-              -H 'Accept: application/vnd.github+json' \
-              -H 'X-GitHub-Api-Version: 2022-11-28' \
-              -q '[.] | flatten | any(.ref == "refs/tags/'$tag'")'
-          )
-          echo "exists=$exists" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set the tag name
-        if: env.RELEASE == 'true' && steps.check-tag-existence.outputs.exists != 'true'
+        if: env.RELEASE == 'true'
         run: |
           tag=${{ needs.config.outputs.tag }}
           release_id=${{ fromJson(needs.create-draft-release.outputs.release).id }}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ VOICEVOX COREで利用するonnxruntimeのビルドを行うリポジトリ
 ## 再リリース
 
 1. リリースのときと同様、[`build`ワークフロー]を`release=true`で起動してdraft releaseを作成。
+   補足: 作成したdraft releaseをブラウザで開くと、"Target"は"Tag"が指すコミット、すなわち古いリリースのコミットになってしまっているように見える。しかしそれはブラウザでの見た目のみであり、実際には`target_commitish`はちゃんと`tag_name`とは別個に設定されている。
 2. 古いリリースをdraft化。
 3. 古いタグを削除。
 4. リリースのときと同様、releaseのdraftを解除する。

--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ VOICEVOX COREで利用するonnxruntimeのビルドを行うリポジトリ
     ```
 3. 古いタグを削除。
 4. リリースのときと同様、releaseのdraftを解除する。
-5. 問題なさそうであれば、2.でdraft化した旧リリースを抹消する。
+5. 問題なさそうであれば、2.でdraft化した古いリリースを削除する。
 
 [`build`ワークフロー]: https://github.com/VOICEVOX/onnxruntime-builder/actions/workflows/build.yml

--- a/README.md
+++ b/README.md
@@ -13,10 +13,7 @@ VOICEVOX COREで利用するonnxruntimeのビルドを行うリポジトリ
 ## 再リリース
 
 1. リリースのときと同様、[`build`ワークフロー]を`release=true`で起動してdraft releaseを作成。
-2. （削除でもいいが念の為、）古いリリースを以下のコマンドでdraft化。
-    ```console
-    id=$(gh api repos/VOICEVOX/onnxruntime-builder/releases --paginate -q 'flatten | .[] | select((.draft | not) and .tag_name == "タグ名").id') && gh api "repos/VOICEVOX/onnxruntime-builder/releases/$id" -X PATCH -F draft=true
-    ```
+2. 古いリリースをdraft化。
 3. 古いタグを削除。
 4. リリースのときと同様、releaseのdraftを解除する。
 5. 問題なさそうであれば、2.でdraft化した古いリリースを削除する。

--- a/README.md
+++ b/README.md
@@ -10,4 +10,15 @@ VOICEVOX COREで利用するonnxruntimeのビルドを行うリポジトリ
 1. [`build`ワークフロー]を`release=true`で起動してdraft releaseを作成。
 2. releaseのdraftを解除する。
 
+## 再リリース
+
+1. リリースのときと同様、[`build`ワークフロー]を`release=true`で起動してdraft releaseを作成。
+2. （削除でもいいが念の為、）古いリリースを以下のコマンドでdraft化。
+    ```console
+    id=$(gh api repos/VOICEVOX/onnxruntime-builder/releases --paginate -q 'flatten | .[] | select((.draft | not) and .tag_name == "タグ名").id') && gh api "repos/VOICEVOX/onnxruntime-builder/releases/$id" -X PATCH -F draft=true
+    ```
+3. 古いタグを削除。
+4. リリースのときと同様、releaseのdraftを解除する。
+5. 問題なさそうであれば、2.でdraft化した旧リリースを抹消する。
+
 [`build`ワークフロー]: https://github.com/VOICEVOX/onnxruntime-builder/actions/workflows/build.yml


### PR DESCRIPTION
## 内容

VOICEVOX/voicevox_core#1262 から実装をコピーして #96 をやる際、「既存の同名のタグがあるかチェックしてあったら拒否」という挙動もコピーしてしまった。しかし本リポジトリにおいては「再ビルドしてリリースを差し替え」ということをおそらく頻繁に行うため、当該チェック機構は不適格である。

~~このPRでは、既存の同名のタグがあったときの挙動を「`tag_name`の設定をスキップする」というものに変える。~~

経緯: https://github.com/VOICEVOX/onnxruntime-builder/issues/115#issuecomment-5044177961
