### PR TITLE
fix: 古いmacOSのバージョンでも動作するようにビルドする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,6 +220,7 @@ jobs:
               --compile_no_warning_as_error
               --cmake_extra_defines
               CMAKE_OSX_ARCHITECTURES=arm64
+              CMAKE_OSX_DEPLOYMENT_TARGET=13.3
             release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-osx-x86_64
             os: macos-15-intel
@@ -229,6 +230,7 @@ jobs:
               --compile_no_warning_as_error
               --cmake_extra_defines
               CMAKE_OSX_ARCHITECTURES=x86_64
+              CMAKE_OSX_DEPLOYMENT_TARGET=13.3
             release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-osx-arm64-webgpu
             os: macos-14
@@ -239,6 +241,7 @@ jobs:
               --compile_no_warning_as_error
               --cmake_extra_defines
               CMAKE_OSX_ARCHITECTURES=arm64
+              CMAKE_OSX_DEPLOYMENT_TARGET=13.3
             release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-osx-x86_64-webgpu
             os: macos-15-intel
@@ -249,6 +252,7 @@ jobs:
               --compile_no_warning_as_error
               --cmake_extra_defines
               CMAKE_OSX_ARCHITECTURES=x86_64
+              CMAKE_OSX_DEPLOYMENT_TARGET=13.3
             release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-android-x64
             os: ubuntu-22.04


### PR DESCRIPTION
## 内容

現在macOS向けビルドにビルドされているvoicevox-onnxruntimeはビルドに使用したOSより古いバージョンでは動作しません。
`CMAKE_OSX_DEPLOYMENT_TARGET=13.3`を追加することでmacOS 13.3以上で動作するようにします。

## 関連 Issue

close #120
ref VOICEVOX/voicevox_project#90

## その他

`CMAKE_OSX_DEPLOYMENT_TARGET`を使う以外に`MACOSX_DEPLOYMENT_TARGET`環境変数を設定する方法もありますが`CMAKE_OSX_DEPLOYMENT_TARGET`の方が`build_opts`だけ変えればいいのでこのようにしました。