### PR TITLE
feat: Windows Arm64のビルドを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,35 @@ jobs:
               --compile_no_warning_as_error
               --x86
             release_config: Release
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-win-arm64
+            os: windows-11-arm
+            spec_os: Windows
+            spec_arch: Arm64
+            build_opts: |-
+              --compile_no_warning_as_error
+              --cmake_extra_defines
+              onnxruntime_BUILD_UNIT_TESTS=OFF
+            release_config: Release
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-win-arm64-dml
+            os: windows-11-arm
+            spec_os: Windows
+            spec_arch: Arm64
+            build_opts: |-
+              --compile_no_warning_as_error
+              --use_dml
+              --cmake_extra_defines
+              onnxruntime_BUILD_UNIT_TESTS=OFF
+            release_config: Release
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-win-arm64-webgpu
+            os: windows-11-arm
+            spec_os: Windows
+            spec_arch: Arm64
+            build_opts: |-
+              --compile_no_warning_as_error
+              --use_webgpu
+              --cmake_extra_defines
+              onnxruntime_BUILD_UNIT_TESTS=OFF
+            release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-linux-x64-webgpu
             os: ubuntu-22.04
             spec_os: Linux
@@ -322,7 +351,8 @@ jobs:
     steps:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.10"
+          # NOTE: Windows ARM64用のPython3.10が配布されていないので代わりに3.11をインストールする
+          python-version: ${{ runner.os == 'Windows' && runner.arch == 'ARM64' && '3.11' || '3.10' }}
 
       - name: Version check (semver)
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,27 @@ jobs:
               --cmake_extra_defines
               onnxruntime_BUILD_UNIT_TESTS=OFF
             release_config: Release
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-win-arm64ec
+            os: windows-11-arm
+            spec_os: Windows
+            spec_arch: Arm64EC
+            build_opts: |-
+              --compile_no_warning_as_error
+              --arm64ec
+              --cmake_extra_defines
+              onnxruntime_BUILD_UNIT_TESTS=OFF
+            release_config: Release
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-win-arm64ec-dml
+            os: windows-11-arm
+            spec_os: Windows
+            spec_arch: Arm64EC
+            build_opts: |-
+              --compile_no_warning_as_error
+              --arm64ec
+              --use_dml
+              --cmake_extra_defines
+              onnxruntime_BUILD_UNIT_TESTS=OFF
+            release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-linux-x64-webgpu
             os: ubuntu-22.04
             spec_os: Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,6 +200,18 @@ jobs:
               --cmake_extra_defines
               onnxruntime_BUILD_UNIT_TESTS=OFF
             release_config: Release
+          - artifact_name: ${{ inputs.target || 'onnxruntime' }}-win-arm64ec-webgpu
+            os: windows-11-arm
+            spec_os: Windows
+            spec_arch: Arm64EC
+            build_opts: |-
+              --compile_no_warning_as_error
+              --arm64ec
+              --use_webgpu
+              --cmake_extra_defines
+              "LLVM_TABLEGEN=$GITHUB_WORKSPACE/Windows_WebGPU_BuildTools/llvm-tblgen.exe"
+              "CLANG_TABLEGEN=$GITHUB_WORKSPACE/Windows_WebGPU_BuildTools/clang-tblgen.exe"
+            release_config: Release
           - artifact_name: ${{ inputs.target || 'onnxruntime' }}-linux-x64-webgpu
             os: ubuntu-22.04
             spec_os: Linux
@@ -576,6 +588,34 @@ jobs:
           build_opts=(
           ${{ matrix.build_opts }}
           )
+
+          if ${{ endsWith(matrix.artifact_name, '-win-arm64ec-webgpu') }}; then
+            # arm64ec-webgputターゲットでビルドすると`llvm-tblgen.exe`と`clang-tblgen.exe`のビルドに失敗する。
+            # これを回避するために事前にarm64ターゲットで`llvm-tblgen.exe`と`clang-tblgen.exe`のみをビルドしてarm64ecビルドでそれを使う。
+            # ref: https://github.com/microsoft/onnxruntime/blob/v1.23.2/tools/ci_build/github/azure-pipelines/stages/nodejs-win-packaging-stage.yml#L92-L106
+            python ./tools/ci_build/build.py \
+              --build_dir ./build \
+              --config Release \
+              --update \
+              --parallel \
+              --build_shared_lib \
+              --compile_no_warning_as_error \
+              --use_webgpu \
+              1${{ env.TARGET_LIBRARY == 'onnxruntime' && '>&1' || format('>> {0}_stdout.txt', matrix.artifact_name) }} \
+              2${{ env.TARGET_LIBRARY == 'onnxruntime' && '>&2' || format('>> {0}_stderr.txt', matrix.artifact_name) }}
+
+            cmake --build ./build/Release \
+              --config Release \
+              --target llvm-tblgen clang-tblgen \
+              1${{ env.TARGET_LIBRARY == 'onnxruntime' && '>&1' || format('>> {0}_stdout.txt', matrix.artifact_name) }} \
+              2${{ env.TARGET_LIBRARY == 'onnxruntime' && '>&2' || format('>> {0}_stderr.txt', matrix.artifact_name) }}
+
+            mkdir ./Windows_WebGPU_BuildTools
+            cp ./build/Release/_deps/dawn-build/third_party/dxc/Release/bin/llvm-tblgen.exe ./Windows_WebGPU_BuildTools
+            cp ./build/Release/_deps/dawn-build/third_party/dxc/Release/bin/clang-tblgen.exe ./Windows_WebGPU_BuildTools
+
+            rm -rf ./build
+          fi
 
           python ./tools/ci_build/build.py \
             --build_dir ./build \


### PR DESCRIPTION
## 内容

Windows Arm64とArm64ECビルドを追加します。
また、それぞれDirectMLとWebGPUのビルドも追加しています。

追記：Arm64ECビルドは別PRに別れました #126

## 関連 Issue

ref VOICEVOX/voicevox_project#84

## その他

コミットは不要と判断したビルドをすぐに取り除けるように
- Arm64 CPU/DirectML/WebGPUビルドの追加
- Arm64EC CPU/DirectMLビルドの追加
- Arm64EC WebGPUビルドの追加

と3つに分けています。